### PR TITLE
Phase 5C: editorial hero sweep across 36 geo pages

### DIFF
--- a/ac-installation-eagle-mountain-ut.html
+++ b/ac-installation-eagle-mountain-ut.html
@@ -186,14 +186,32 @@
             </div>
         </section>
 
-        <section class="hero geo-hero" aria-label="Hero section">
-            <div class="hero-content">
-                <h1>AC Installation in Eagle Mountain, UT</h1>
-                <p class="tagline">New Construction Specialists • System Selection & Installation • NATE-Certified</p>
-                <p>Air Express provides professional AC installation for Eagle Mountain homes. Whether you're building new or replacing an aging system, we handle the entire process with precision and care. Free estimates. Licensed and certified. Call (801) 766-8585.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/ac-service-action-utah-1200.webp'); --hero-bg-desktop: url('/images/ac-service-action-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">AC INSTALLATION · CLEAN WORK · EAGLE MOUNTAIN, UTAH</p>
+                <h1>A new AC in Eagle Mountain,<br>installed clean.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — 15 minutes west of Lehi. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -254,12 +272,20 @@
             </div>
         </section>
 
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Ready for AC Installation in Eagle Mountain?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">Get a free estimate. No obligation. Expert installation.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · EAGLE MOUNTAIN</p>
+                <h2>Tell us what's going on with your AC.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No pressure, no upsell, no call center.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -273,70 +299,6 @@
                 <a role="menuitem" href="heat-pump.html">Heat Pumps</a>
                 <a role="menuitem" href="ventilation.html">Ventilation & ERV</a>
                 <a role="menuitem" href="air-filters.html">Air Filters</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
-        </div>
-<script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                toggle.setAttribute('aria-expanded', nav.classList.contains('active'));
-            });
-        }
-    })();
-    </script>
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
                 <a role="menuitem" href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">

--- a/ac-installation-lehi-ut.html
+++ b/ac-installation-lehi-ut.html
@@ -102,7 +102,7 @@
                 "name": "What makes Air Express the best choice for AC Installation in Lehi?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "nearly 30 years serving Lehi and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
+                    "text": "thirty years serving Lehi and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
                 }
             }
         ]
@@ -199,14 +199,32 @@
         </section>
 
         <!-- HERO -->
-        <section class="hero geo-hero" aria-label="Hero section">
-            <div class="hero-content">
-                <h1>Expert AC Installation in Lehi, UT</h1>
-                <p class="tagline">NATE-Certified Technicians • Same-Day Service • Nearly 30 Years of Local Expertise</p>
-                <p>Air Express provides professional AC Installation throughout Lehi. Licensed, certified, and ready to solve your HVAC challenges. Call (801) 766-8585 for a free estimate—we're just 15-20 minutes away.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/ac-service-action-utah-1200.webp'); --hero-bg-desktop: url('/images/ac-service-action-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">AC INSTALLATION · CLEAN WORK · LEHI, UTAH</p>
+                <h1>A new AC in Lehi,<br>installed clean.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — our hometown since 1996. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -228,7 +246,7 @@
 
                 <h3>Why Choose Air Express for AC Installation in Lehi?</h3>
                 <ul style="line-height: 1.8;">
-                    <li>nearly 30 years serving Lehi and surrounding communities since 1996</li>
+                    <li>thirty years serving Lehi and surrounding communities since 1996</li>
                     <li>NATE-certified technicians with deep heating and cooling expertise</li>
                     <li>4.9-star rating from 280+ satisfied Lehi neighbors</li>
                     <li>Same-day service available—we're minutes away from Lehi</li>
@@ -270,7 +288,7 @@
                     </details>
                     <details>
                         <summary><strong>What makes Air Express different for AC Installation in Lehi?</strong></summary>
-                        <p>We're not a call center—we're your neighbors. nearly 30 years in Lehi. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Lehi's unique HVAC challenges and deliver solutions that last.</p>
+                        <p>We're not a call center—we're your neighbors. thirty years in Lehi. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Lehi's unique HVAC challenges and deliver solutions that last.</p>
                     </details>
                 </div>
 
@@ -280,12 +298,20 @@
         </section>
 
         <!-- CTA SECTION -->
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Need AC Installation in Lehi?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">Get a free estimate today. No obligation. Transparent pricing.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · LEHI</p>
+                <h2>Tell us what's going on with your AC.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No pressure, no upsell, no call center.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -335,76 +361,6 @@
         <div class="footer-bottom">
             <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-
-    <!-- Navigation Script -->
-    <script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                var expanded = nav.classList.contains('active');
-                toggle.setAttribute('aria-expanded', expanded);
-            });
-        }
-    })();
-    </script>
-    
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
-        </div>
-    </footer>
 <button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>

--- a/ac-installation-orem-ut.html
+++ b/ac-installation-orem-ut.html
@@ -102,7 +102,7 @@
                 "name": "What makes Air Express the best choice for AC Installation in Orem?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "nearly 30 years serving Orem and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
+                    "text": "thirty years serving Orem and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
                 }
             }
         ]
@@ -199,14 +199,32 @@
         </section>
 
         <!-- HERO -->
-        <section class="hero geo-hero" aria-label="Hero section">
-            <div class="hero-content">
-                <h1>Expert AC Installation in Orem, UT</h1>
-                <p class="tagline">NATE-Certified Technicians • Same-Day Service • Nearly 30 Years of Local Expertise</p>
-                <p>Air Express provides professional AC Installation throughout Orem. Licensed, certified, and ready to solve your HVAC challenges. Call (801) 766-8585 for a free estimate—we're just 20-25 minutes away.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/ac-service-action-utah-1200.webp'); --hero-bg-desktop: url('/images/ac-service-action-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">AC INSTALLATION · CLEAN WORK · OREM, UTAH</p>
+                <h1>A new AC in Orem,<br>installed clean.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — 20 minutes south on I-15. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -220,7 +238,7 @@
                 <div class="city-facts-box">
                     <h3>What Orem Homeowners Should Know</h3>
                     <ul>
-                        <li><strong>Local expertise:</strong> Orem's diverse housing—from vintage duplexes near campus to newer family homes in surrounding subdivisions—means we service every type of system. BYU-area families know they can trust our crew. We've been keeping Orem comfortable through harsh winters and scorching summers for over nearly 30 years.</li>
+                        <li><strong>Local expertise:</strong> Orem's diverse housing—from vintage duplexes near campus to newer family homes in surrounding subdivisions—means we service every type of system. BYU-area families know they can trust our crew. We've been keeping Orem comfortable through harsh winters and scorching summers for over thirty years.</li>
                         <li><strong>Emergency availability:</strong> We're available 24/7 for furnace failures and AC breakdowns. From our Lehi headquarters, we typically respond to Orem within 20-25 minutes.</li>
                         <li><strong>Certifications & licensing:</strong> Our technicians are NATE-certified, EPA-certified, and hold Utah HVAC license #96-324211-550. We maintain the highest standards on every job.</li>
                     </ul>
@@ -228,7 +246,7 @@
 
                 <h3>Why Choose Air Express for AC Installation in Orem?</h3>
                 <ul style="line-height: 1.8;">
-                    <li>nearly 30 years serving Orem and surrounding communities since 1996</li>
+                    <li>thirty years serving Orem and surrounding communities since 1996</li>
                     <li>NATE-certified technicians with deep heating and cooling expertise</li>
                     <li>4.9-star rating from 280+ satisfied Orem neighbors</li>
                     <li>Same-day service available—we're minutes away from Orem</li>
@@ -270,7 +288,7 @@
                     </details>
                     <details>
                         <summary><strong>What makes Air Express different for AC Installation in Orem?</strong></summary>
-                        <p>We're not a call center—we're your neighbors. nearly 30 years in Orem. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Orem's unique HVAC challenges and deliver solutions that last.</p>
+                        <p>We're not a call center—we're your neighbors. thirty years in Orem. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Orem's unique HVAC challenges and deliver solutions that last.</p>
                     </details>
                 </div>
 
@@ -280,12 +298,20 @@
         </section>
 
         <!-- CTA SECTION -->
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Need AC Installation in Orem?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">Get a free estimate today. No obligation. Transparent pricing.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · OREM</p>
+                <h2>Tell us what's going on with your AC.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No pressure, no upsell, no call center.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -335,76 +361,6 @@
         <div class="footer-bottom">
             <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-
-    <!-- Navigation Script -->
-    <script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                var expanded = nav.classList.contains('active');
-                toggle.setAttribute('aria-expanded', expanded);
-            });
-        }
-    })();
-    </script>
-    
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
-        </div>
-    </footer>
 <button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>

--- a/ac-installation-sandy-ut.html
+++ b/ac-installation-sandy-ut.html
@@ -102,7 +102,7 @@
                 "name": "What makes Air Express the best choice for AC Installation in Sandy?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "nearly 30 years serving Sandy and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
+                    "text": "thirty years serving Sandy and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
                 }
             }
         ]
@@ -199,14 +199,32 @@
         </section>
 
         <!-- HERO -->
-        <section class="hero geo-hero" aria-label="Hero section">
-            <div class="hero-content">
-                <h1>Expert AC Installation in Sandy, UT</h1>
-                <p class="tagline">NATE-Certified Technicians • Same-Day Service • Nearly 30 Years of Local Expertise</p>
-                <p>Air Express provides professional AC Installation throughout Sandy. Licensed, certified, and ready to solve your HVAC challenges. Call (801) 766-8585 for a free estimate—we're just 35-40 minutes away.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/ac-service-action-utah-1200.webp'); --hero-bg-desktop: url('/images/ac-service-action-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">AC INSTALLATION · CLEAN WORK · SANDY, UTAH</p>
+                <h1>A new AC in Sandy,<br>installed clean.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — 25 minutes up I-15. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -228,7 +246,7 @@
 
                 <h3>Why Choose Air Express for AC Installation in Sandy?</h3>
                 <ul style="line-height: 1.8;">
-                    <li>nearly 30 years serving Sandy and surrounding communities since 1996</li>
+                    <li>thirty years serving Sandy and surrounding communities since 1996</li>
                     <li>NATE-certified technicians with deep heating and cooling expertise</li>
                     <li>4.9-star rating from 280+ satisfied Sandy neighbors</li>
                     <li>Same-day service available—we're minutes away from Sandy</li>
@@ -270,7 +288,7 @@
                     </details>
                     <details>
                         <summary><strong>What makes Air Express different for AC Installation in Sandy?</strong></summary>
-                        <p>We're not a call center—we're your neighbors. nearly 30 years in Sandy. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Sandy's unique HVAC challenges and deliver solutions that last.</p>
+                        <p>We're not a call center—we're your neighbors. thirty years in Sandy. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Sandy's unique HVAC challenges and deliver solutions that last.</p>
                     </details>
                 </div>
 
@@ -280,12 +298,20 @@
         </section>
 
         <!-- CTA SECTION -->
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Need AC Installation in Sandy?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">Get a free estimate today. No obligation. Transparent pricing.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · SANDY</p>
+                <h2>Tell us what's going on with your AC.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No pressure, no upsell, no call center.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -335,76 +361,6 @@
         <div class="footer-bottom">
             <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-
-    <!-- Navigation Script -->
-    <script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                var expanded = nav.classList.contains('active');
-                toggle.setAttribute('aria-expanded', expanded);
-            });
-        }
-    })();
-    </script>
-    
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
-        </div>
-    </footer>
 <button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>

--- a/ac-installation-saratoga-springs-ut.html
+++ b/ac-installation-saratoga-springs-ut.html
@@ -118,14 +118,32 @@
             </div>
         </section>
 
-        <section class="hero geo-hero">
-            <div class="hero-content">
-                <h1>AC Installation in Saratoga Springs, UT</h1>
-                <p class="tagline">Humidity-Optimized Systems • System Selection & Installation • NATE-Certified</p>
-                <p>Air Express provides professional AC installation for Saratoga Springs homes. We select and install systems optimized for your lakeside environment and humidity levels. Free estimates. Licensed and certified. Call (801) 766-8585.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/ac-service-action-utah-1200.webp'); --hero-bg-desktop: url('/images/ac-service-action-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">AC INSTALLATION · CLEAN WORK · SARATOGA SPRINGS, UTAH</p>
+                <h1>A new AC in Saratoga Springs,<br>installed clean.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — 15 minutes west of Lehi. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -182,12 +200,20 @@
             </div>
         </section>
 
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Ready for AC Installation in Saratoga Springs?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">Get a free estimate. Humidity-optimized systems.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · SARATOGA SPRINGS</p>
+                <h2>Tell us what's going on with your AC.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No pressure, no upsell, no call center.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -203,70 +229,6 @@
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom"><p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved.</p></div>
-<script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                toggle.setAttribute('aria-expanded', nav.classList.contains('active'));
-            });
-        }
-    })();
-    </script>
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
-        </div>
     </footer>
 <button class="back-to-top" aria-label="Back to top"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="18 15 12 9 6 15"></polyline></svg></button>
 <script src="nav.js" defer></script>

--- a/ac-repair-eagle-mountain-ut.html
+++ b/ac-repair-eagle-mountain-ut.html
@@ -102,7 +102,7 @@
                 "name": "What makes Air Express the best choice for AC Repair in Eagle Mountain?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "nearly 30 years serving Utah Valley communities. NATE-certified technicians with new-construction expertise. 4.9-star reviews. We understand Eagle Mountain's unique elevation (~4,800 ft) and construction environment. Emergency availability 24/7. Transparent pricing."
+                    "text": "thirty years serving Utah Valley communities. NATE-certified technicians with new-construction expertise. 4.9-star reviews. We understand Eagle Mountain's unique elevation (~4,800 ft) and construction environment. Emergency availability 24/7. Transparent pricing."
                 }
             }
         ]
@@ -199,14 +199,32 @@
         </section>
 
         <!-- HERO -->
-        <section class="hero geo-hero" aria-label="Hero section">
-            <div class="hero-content">
-                <h1>Expert AC Repair in Eagle Mountain, UT</h1>
-                <p class="tagline">NATE-Certified Technicians • New-Construction Specialists • 20-Minute Response Time</p>
-                <p>Air Express provides professional AC Repair throughout Eagle Mountain. We specialize in new-construction HVAC systems and construction dust mitigation. Licensed, certified, and ready to keep your system running smoothly. Call (801) 766-8585 for a free estimate.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/ac-repair-utah-1200.webp'); --hero-bg-desktop: url('/images/ac-repair-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">AC REPAIR · SAME-DAY · EAGLE MOUNTAIN, UTAH</p>
+                <h1>When your AC quits in Eagle Mountain,<br>we're on our way.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — 15 minutes west of Lehi. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -229,7 +247,7 @@
 
                 <h3>Why Choose Air Express for AC Repair in Eagle Mountain?</h3>
                 <ul style="line-height: 1.8;">
-                    <li>nearly 30 years serving Utah Valley and growing communities since 1996</li>
+                    <li>thirty years serving Utah Valley and growing communities since 1996</li>
                     <li>NATE-certified technicians with new-construction and high-elevation expertise</li>
                     <li>4.9-star rating from 280+ satisfied Eagle Mountain neighbors</li>
                     <li>20-minute response time from Lehi—we're closer than you think</li>
@@ -273,7 +291,7 @@
                     </details>
                     <details>
                         <summary><strong>What makes Air Express different for AC Repair in Eagle Mountain?</strong></summary>
-                        <p>We specialize in new-construction systems and understand Eagle Mountain's unique environment. nearly 30 years experience. NATE-certified technicians. 4.9-star reviews. 20-minute response time. Transparent pricing. We're your Eagle Mountain HVAC neighbors.</p>
+                        <p>We specialize in new-construction systems and understand Eagle Mountain's unique environment. thirty years experience. NATE-certified technicians. 4.9-star reviews. 20-minute response time. Transparent pricing. We're your Eagle Mountain HVAC neighbors.</p>
                     </details>
                 </div>
 
@@ -283,12 +301,20 @@
         </section>
 
         <!-- CTA SECTION -->
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Need AC Repair in Eagle Mountain?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">Get a free estimate today. No obligation. Transparent pricing.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · EAGLE MOUNTAIN</p>
+                <h2>Tell us what's going on with your AC.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No pressure, no upsell, no call center.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -338,76 +364,6 @@
         <div class="footer-bottom">
             <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-
-    <!-- Navigation Script -->
-    <script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                var expanded = nav.classList.contains('active');
-                toggle.setAttribute('aria-expanded', expanded);
-            });
-        }
-    })();
-    </script>
-    
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
-        </div>
-    </footer>
 <button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>

--- a/ac-repair-lehi-ut.html
+++ b/ac-repair-lehi-ut.html
@@ -102,7 +102,7 @@
                 "name": "What makes Air Express the best choice for AC Repair in Lehi?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "nearly 30 years serving Lehi and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
+                    "text": "thirty years serving Lehi and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
                 }
             }
         ]
@@ -199,14 +199,32 @@
         </section>
 
         <!-- HERO -->
-        <section class="hero geo-hero" aria-label="Hero section">
-            <div class="hero-content">
-                <h1>Expert AC Repair in Lehi, UT</h1>
-                <p class="tagline">NATE-Certified Technicians • Same-Day Service • Nearly 30 Years of Local Expertise</p>
-                <p>Air Express provides professional AC Repair throughout Lehi. Licensed, certified, and ready to solve your HVAC challenges. Call (801) 766-8585 for a free estimate—we're just 15-20 minutes away.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/ac-repair-utah-1200.webp'); --hero-bg-desktop: url('/images/ac-repair-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">AC REPAIR · SAME-DAY · LEHI, UTAH</p>
+                <h1>When your AC quits in Lehi,<br>we're on our way.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — our hometown since 1996. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -228,7 +246,7 @@
 
                 <h3>Why Choose Air Express for AC Repair in Lehi?</h3>
                 <ul style="line-height: 1.8;">
-                    <li>nearly 30 years serving Lehi and surrounding communities since 1996</li>
+                    <li>thirty years serving Lehi and surrounding communities since 1996</li>
                     <li>NATE-certified technicians with deep heating and cooling expertise</li>
                     <li>4.9-star rating from 280+ satisfied Lehi neighbors</li>
                     <li>Same-day service available—we're minutes away from Lehi</li>
@@ -270,7 +288,7 @@
                     </details>
                     <details>
                         <summary><strong>What makes Air Express different for AC Repair in Lehi?</strong></summary>
-                        <p>We're not a call center—we're your neighbors. nearly 30 years in Lehi. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Lehi's unique HVAC challenges and deliver solutions that last.</p>
+                        <p>We're not a call center—we're your neighbors. thirty years in Lehi. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Lehi's unique HVAC challenges and deliver solutions that last.</p>
                     </details>
                 </div>
 
@@ -280,12 +298,20 @@
         </section>
 
         <!-- CTA SECTION -->
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Need AC Repair in Lehi?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">Get a free estimate today. No obligation. Transparent pricing.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · LEHI</p>
+                <h2>Tell us what's going on with your AC.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No pressure, no upsell, no call center.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -335,76 +361,6 @@
         <div class="footer-bottom">
             <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-
-    <!-- Navigation Script -->
-    <script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                var expanded = nav.classList.contains('active');
-                toggle.setAttribute('aria-expanded', expanded);
-            });
-        }
-    })();
-    </script>
-    
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
-        </div>
-    </footer>
 <button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>

--- a/ac-repair-orem-ut.html
+++ b/ac-repair-orem-ut.html
@@ -102,7 +102,7 @@
                 "name": "What makes Air Express the best choice for AC Repair in Orem?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "nearly 30 years serving Orem and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
+                    "text": "thirty years serving Orem and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
                 }
             }
         ]
@@ -199,14 +199,32 @@
         </section>
 
         <!-- HERO -->
-        <section class="hero geo-hero" aria-label="Hero section">
-            <div class="hero-content">
-                <h1>Expert AC Repair in Orem, UT</h1>
-                <p class="tagline">NATE-Certified Technicians • Same-Day Service • Nearly 30 Years of Local Expertise</p>
-                <p>Air Express provides professional AC Repair throughout Orem. Licensed, certified, and ready to solve your HVAC challenges. Call (801) 766-8585 for a free estimate—we're just 20-25 minutes away.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/ac-repair-utah-1200.webp'); --hero-bg-desktop: url('/images/ac-repair-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">AC REPAIR · SAME-DAY · OREM, UTAH</p>
+                <h1>When your AC quits in Orem,<br>we're on our way.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — 20 minutes south on I-15. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -220,7 +238,7 @@
                 <div class="city-facts-box">
                     <h3>What Orem Homeowners Should Know</h3>
                     <ul>
-                        <li><strong>Local expertise:</strong> Orem's diverse housing—from vintage duplexes near campus to newer family homes in surrounding subdivisions—means we service every type of system. BYU-area families know they can trust our crew. We've been keeping Orem comfortable through harsh winters and scorching summers for over nearly 30 years.</li>
+                        <li><strong>Local expertise:</strong> Orem's diverse housing—from vintage duplexes near campus to newer family homes in surrounding subdivisions—means we service every type of system. BYU-area families know they can trust our crew. We've been keeping Orem comfortable through harsh winters and scorching summers for over thirty years.</li>
                         <li><strong>Emergency availability:</strong> We're available 24/7 for furnace failures and AC breakdowns. From our Lehi headquarters, we typically respond to Orem within 20-25 minutes.</li>
                         <li><strong>Certifications & licensing:</strong> Our technicians are NATE-certified, EPA-certified, and hold Utah HVAC license #96-324211-550. We maintain the highest standards on every job.</li>
                     </ul>
@@ -228,7 +246,7 @@
 
                 <h3>Why Choose Air Express for AC Repair in Orem?</h3>
                 <ul style="line-height: 1.8;">
-                    <li>nearly 30 years serving Orem and surrounding communities since 1996</li>
+                    <li>thirty years serving Orem and surrounding communities since 1996</li>
                     <li>NATE-certified technicians with deep heating and cooling expertise</li>
                     <li>4.9-star rating from 280+ satisfied Orem neighbors</li>
                     <li>Same-day service available—we're minutes away from Orem</li>
@@ -270,7 +288,7 @@
                     </details>
                     <details>
                         <summary><strong>What makes Air Express different for AC Repair in Orem?</strong></summary>
-                        <p>We're not a call center—we're your neighbors. nearly 30 years in Orem. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Orem's unique HVAC challenges and deliver solutions that last.</p>
+                        <p>We're not a call center—we're your neighbors. thirty years in Orem. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Orem's unique HVAC challenges and deliver solutions that last.</p>
                     </details>
                 </div>
 
@@ -280,12 +298,20 @@
         </section>
 
         <!-- CTA SECTION -->
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Need AC Repair in Orem?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">Get a free estimate today. No obligation. Transparent pricing.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · OREM</p>
+                <h2>Tell us what's going on with your AC.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No pressure, no upsell, no call center.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -335,76 +361,6 @@
         <div class="footer-bottom">
             <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-
-    <!-- Navigation Script -->
-    <script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                var expanded = nav.classList.contains('active');
-                toggle.setAttribute('aria-expanded', expanded);
-            });
-        }
-    })();
-    </script>
-    
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
-        </div>
-    </footer>
 <button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>

--- a/ac-repair-sandy-ut.html
+++ b/ac-repair-sandy-ut.html
@@ -102,7 +102,7 @@
                 "name": "What makes Air Express the best choice for AC Repair in Sandy?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "nearly 30 years serving Sandy and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
+                    "text": "thirty years serving Sandy and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
                 }
             }
         ]
@@ -199,14 +199,32 @@
         </section>
 
         <!-- HERO -->
-        <section class="hero geo-hero" aria-label="Hero section">
-            <div class="hero-content">
-                <h1>Expert AC Repair in Sandy, UT</h1>
-                <p class="tagline">NATE-Certified Technicians • Same-Day Service • Nearly 30 Years of Local Expertise</p>
-                <p>Air Express provides professional AC Repair throughout Sandy. Licensed, certified, and ready to solve your HVAC challenges. Call (801) 766-8585 for a free estimate—we're just 35-40 minutes away.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/ac-repair-utah-1200.webp'); --hero-bg-desktop: url('/images/ac-repair-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">AC REPAIR · SAME-DAY · SANDY, UTAH</p>
+                <h1>When your AC quits in Sandy,<br>we're on our way.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — 25 minutes up I-15. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -228,7 +246,7 @@
 
                 <h3>Why Choose Air Express for AC Repair in Sandy?</h3>
                 <ul style="line-height: 1.8;">
-                    <li>nearly 30 years serving Sandy and surrounding communities since 1996</li>
+                    <li>thirty years serving Sandy and surrounding communities since 1996</li>
                     <li>NATE-certified technicians with deep heating and cooling expertise</li>
                     <li>4.9-star rating from 280+ satisfied Sandy neighbors</li>
                     <li>Same-day service available—we're minutes away from Sandy</li>
@@ -270,7 +288,7 @@
                     </details>
                     <details>
                         <summary><strong>What makes Air Express different for AC Repair in Sandy?</strong></summary>
-                        <p>We're not a call center—we're your neighbors. nearly 30 years in Sandy. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Sandy's unique HVAC challenges and deliver solutions that last.</p>
+                        <p>We're not a call center—we're your neighbors. thirty years in Sandy. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Sandy's unique HVAC challenges and deliver solutions that last.</p>
                     </details>
                 </div>
 
@@ -280,12 +298,20 @@
         </section>
 
         <!-- CTA SECTION -->
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Need AC Repair in Sandy?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">Get a free estimate today. No obligation. Transparent pricing.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · SANDY</p>
+                <h2>Tell us what's going on with your AC.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No pressure, no upsell, no call center.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -335,76 +361,6 @@
         <div class="footer-bottom">
             <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-
-    <!-- Navigation Script -->
-    <script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                var expanded = nav.classList.contains('active');
-                toggle.setAttribute('aria-expanded', expanded);
-            });
-        }
-    })();
-    </script>
-    
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
-        </div>
-    </footer>
 <button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>

--- a/ac-repair-saratoga-springs-ut.html
+++ b/ac-repair-saratoga-springs-ut.html
@@ -100,7 +100,7 @@
                 "name": "What makes Air Express the best choice for AC Repair in Saratoga Springs?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "nearly 30 years serving Saratoga Springs and Utah Valley. NATE-certified technicians. 4.9-star reviews. 15-minute response time. We understand Saratoga Springs' unique humidity challenges. Transparent pricing. 24/7 emergency service."
+                    "text": "thirty years serving Saratoga Springs and Utah Valley. NATE-certified technicians. 4.9-star reviews. 15-minute response time. We understand Saratoga Springs' unique humidity challenges. Transparent pricing. 24/7 emergency service."
                 }
             }
         ]
@@ -186,14 +186,32 @@
             </div>
         </section>
 
-        <section class="hero geo-hero">
-            <div class="hero-content">
-                <h1>Expert AC Repair in Saratoga Springs, UT</h1>
-                <p class="tagline">NATE-Certified Technicians • Humidity Control Specialists • 15-Minute Response</p>
-                <p>Air Express provides professional AC Repair throughout Saratoga Springs. We specialize in humidity management for lakeside homes and serve both new and established neighborhoods. Licensed, certified, and just 15 minutes away. Call (801) 766-8585 for a free estimate.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/ac-repair-utah-1200.webp'); --hero-bg-desktop: url('/images/ac-repair-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">AC REPAIR · SAME-DAY · SARATOGA SPRINGS, UTAH</p>
+                <h1>When your AC quits in Saratoga Springs,<br>we're on our way.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — 15 minutes west of Lehi. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -215,7 +233,7 @@
 
                 <h3>Why Choose Air Express for AC Repair in Saratoga Springs?</h3>
                 <ul style="line-height: 1.8;">
-                    <li>nearly 30 years serving Saratoga Springs and Utah Valley since 1996</li>
+                    <li>thirty years serving Saratoga Springs and Utah Valley since 1996</li>
                     <li>NATE-certified technicians with humidity control expertise</li>
                     <li>4.9-star rating from 280+ satisfied Saratoga Springs neighbors</li>
                     <li>15-minute response time from Lehi—we're your closest expert</li>
@@ -258,7 +276,7 @@
                     </details>
                     <details>
                         <summary><strong>What makes Air Express different for AC Repair in Saratoga Springs?</strong></summary>
-                        <p>We understand Saratoga Springs' unique humidity environment. nearly 30 years experience. NATE-certified technicians. 4.9-star reviews. 15-minute response time. Transparent pricing. We're your Saratoga Springs HVAC neighbors.</p>
+                        <p>We understand Saratoga Springs' unique humidity environment. thirty years experience. NATE-certified technicians. 4.9-star reviews. 15-minute response time. Transparent pricing. We're your Saratoga Springs HVAC neighbors.</p>
                     </details>
                 </div>
 
@@ -267,12 +285,20 @@
             </div>
         </section>
 
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Need AC Repair in Saratoga Springs?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">Get a free estimate today. No obligation. Transparent pricing.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · SARATOGA SPRINGS</p>
+                <h2>Tell us what's going on with your AC.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No pressure, no upsell, no call center.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -317,70 +343,6 @@
         </div>
         <div class="footer-bottom">
             <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved.</p>
-        </div>
-<script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                toggle.setAttribute('aria-expanded', nav.classList.contains('active'));
-            });
-        }
-    })();
-    </script>
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
     </footer>
 <button class="back-to-top" aria-label="Back to top">

--- a/furnace-repair-eagle-mountain-ut.html
+++ b/furnace-repair-eagle-mountain-ut.html
@@ -100,7 +100,7 @@
                 "name": "What makes Air Express the best choice for furnace repair in Eagle Mountain?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "nearly 30 years serving Utah Valley. New-construction expertise. NATE-certified technicians. 4.9-star reviews. 20-minute response time. 24/7 emergency availability. Transparent pricing. We understand Eagle Mountain's modern homes and unique heating needs."
+                    "text": "thirty years serving Utah Valley. New-construction expertise. NATE-certified technicians. 4.9-star reviews. 20-minute response time. 24/7 emergency availability. Transparent pricing. We understand Eagle Mountain's modern homes and unique heating needs."
                 }
             }
         ]
@@ -190,14 +190,32 @@
             </div>
         </section>
 
-        <section class="hero geo-hero" aria-label="Hero section">
-            <div class="hero-content">
-                <h1>Expert Furnace Repair in Eagle Mountain, UT</h1>
-                <p class="tagline">NATE-Certified Technicians • Emergency Service 24/7 • 20-Minute Response</p>
-                <p>Air Express provides professional furnace repair for Eagle Mountain homes. Whether your new-construction furnace needs commissioning or your system fails on a winter night, we're ready. Licensed, certified, and just 20 minutes away. Call (801) 766-8585 for emergency service anytime.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/maintenance-furnace-utah-1200.webp'); --hero-bg-desktop: url('/images/maintenance-furnace-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FURNACE REPAIR · 24/7 · EAGLE MOUNTAIN, UTAH</p>
+                <h1>Furnace down in Eagle Mountain?<br>We're driving over.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — 15 minutes west of Lehi. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -213,13 +231,13 @@
                         <li><strong>New-system expertise:</strong> Most Eagle Mountain homes have modern furnaces still under warranty. We specialize in commissioning, tuning, and warranty repairs. Our technicians understand high-efficiency systems and can optimize performance.</li>
                         <li><strong>Winter reliability:</strong> Eagle Mountain winters are cold, and furnace failure is not an option. We provide 24/7 emergency service and typically respond within 20 minutes from our Lehi headquarters.</li>
                         <li><strong>High-elevation heating:</strong> At ~4,800 feet, Eagle Mountain has unique heating demands. Our technicians are trained in high-elevation furnace optimization.</li>
-                        <li><strong>Local partnership:</strong> We've served Eagle Mountain and Utah Valley for nearly 30 years. You're not calling a call center—you're reaching your neighbors.</li>
+                        <li><strong>Local partnership:</strong> We've served Eagle Mountain and Utah Valley for thirty years. You're not calling a call center—you're reaching your neighbors.</li>
                     </ul>
                 </div>
 
                 <h3>Why Choose Air Express for Furnace Repair in Eagle Mountain?</h3>
                 <ul style="line-height: 1.8;">
-                    <li>nearly 30 years serving Eagle Mountain and Utah Valley since 1996</li>
+                    <li>thirty years serving Eagle Mountain and Utah Valley since 1996</li>
                     <li>NATE-certified technicians with new-construction and high-efficiency expertise</li>
                     <li>4.9-star rating from 280+ satisfied Eagle Mountain families</li>
                     <li>20-minute response time from Lehi—we're your closest expert</li>
@@ -262,7 +280,7 @@
                     </details>
                     <details>
                         <summary><strong>What makes Air Express different for furnace repair in Eagle Mountain?</strong></summary>
-                        <p>We understand Eagle Mountain's newer homes and modern furnace systems. nearly 30 years experience. NATE-certified technicians. 4.9-star reviews. 20-minute response time. 24/7 emergency availability. Transparent pricing. We're your Eagle Mountain heating experts.</p>
+                        <p>We understand Eagle Mountain's newer homes and modern furnace systems. thirty years experience. NATE-certified technicians. 4.9-star reviews. 20-minute response time. 24/7 emergency availability. Transparent pricing. We're your Eagle Mountain heating experts.</p>
                     </details>
                 </div>
 
@@ -271,12 +289,20 @@
             </div>
         </section>
 
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Need Furnace Repair in Eagle Mountain?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">24/7 emergency service. Free estimates. No obligation.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · EAGLE MOUNTAIN</p>
+                <h2>Tell us what's going on with your heat.</h2>
+                <p>We'll come take a look, diagnose the real problem, and give you a written estimate before any work starts. If it's an emergency, call — we answer the phone and we're on the way.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -290,71 +316,6 @@
                 <a role="menuitem" href="heat-pump.html">Heat Pumps</a>
                 <a role="menuitem" href="ventilation.html">Ventilation & ERV</a>
                 <a role="menuitem" href="air-filters.html">Air Filters</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
-        </div>
-<script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                var expanded = nav.classList.contains('active');
-                toggle.setAttribute('aria-expanded', expanded);
-            });
-        }
-    })();
-    </script>
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
                 <a role="menuitem" href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">

--- a/furnace-repair-lehi-ut.html
+++ b/furnace-repair-lehi-ut.html
@@ -102,7 +102,7 @@
                 "name": "What makes Air Express the best choice for Furnace Repair in Lehi?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "nearly 30 years serving Lehi and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
+                    "text": "thirty years serving Lehi and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
                 }
             }
         ]
@@ -199,14 +199,32 @@
         </section>
 
         <!-- HERO -->
-        <section class="hero geo-hero" aria-label="Hero section">
-            <div class="hero-content">
-                <h1>Expert Furnace Repair in Lehi, UT</h1>
-                <p class="tagline">NATE-Certified Technicians • Same-Day Service • Nearly 30 Years of Local Expertise</p>
-                <p>Air Express provides professional Furnace Repair throughout Lehi. Licensed, certified, and ready to solve your HVAC challenges. Call (801) 766-8585 for a free estimate—we're just 15-20 minutes away.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/maintenance-furnace-utah-1200.webp'); --hero-bg-desktop: url('/images/maintenance-furnace-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FURNACE REPAIR · 24/7 · LEHI, UTAH</p>
+                <h1>Furnace down in Lehi?<br>We're driving over.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — our hometown since 1996. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -228,7 +246,7 @@
 
                 <h3>Why Choose Air Express for Furnace Repair in Lehi?</h3>
                 <ul style="line-height: 1.8;">
-                    <li>nearly 30 years serving Lehi and surrounding communities since 1996</li>
+                    <li>thirty years serving Lehi and surrounding communities since 1996</li>
                     <li>NATE-certified technicians with deep heating and cooling expertise</li>
                     <li>4.9-star rating from 280+ satisfied Lehi neighbors</li>
                     <li>Same-day service available—we're minutes away from Lehi</li>
@@ -270,7 +288,7 @@
                     </details>
                     <details>
                         <summary><strong>What makes Air Express different for Furnace Repair in Lehi?</strong></summary>
-                        <p>We're not a call center—we're your neighbors. nearly 30 years in Lehi. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Lehi's unique HVAC challenges and deliver solutions that last.</p>
+                        <p>We're not a call center—we're your neighbors. thirty years in Lehi. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Lehi's unique HVAC challenges and deliver solutions that last.</p>
                     </details>
                 </div>
 
@@ -280,12 +298,20 @@
         </section>
 
         <!-- CTA SECTION -->
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Need Furnace Repair in Lehi?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">Get a free estimate today. No obligation. Transparent pricing.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · LEHI</p>
+                <h2>Tell us what's going on with your heat.</h2>
+                <p>We'll come take a look, diagnose the real problem, and give you a written estimate before any work starts. If it's an emergency, call — we answer the phone and we're on the way.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -335,76 +361,6 @@
         <div class="footer-bottom">
             <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-
-    <!-- Navigation Script -->
-    <script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                var expanded = nav.classList.contains('active');
-                toggle.setAttribute('aria-expanded', expanded);
-            });
-        }
-    })();
-    </script>
-    
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
-        </div>
-    </footer>
 <button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>

--- a/furnace-repair-orem-ut.html
+++ b/furnace-repair-orem-ut.html
@@ -102,7 +102,7 @@
                 "name": "What makes Air Express the best choice for Furnace Repair in Orem?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "nearly 30 years serving Orem and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
+                    "text": "thirty years serving Orem and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
                 }
             }
         ]
@@ -199,14 +199,32 @@
         </section>
 
         <!-- HERO -->
-        <section class="hero geo-hero" aria-label="Hero section">
-            <div class="hero-content">
-                <h1>Expert Furnace Repair in Orem, UT</h1>
-                <p class="tagline">NATE-Certified Technicians • Same-Day Service • Nearly 30 Years of Local Expertise</p>
-                <p>Air Express provides professional Furnace Repair throughout Orem. Licensed, certified, and ready to solve your HVAC challenges. Call (801) 766-8585 for a free estimate—we're just 20-25 minutes away.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/maintenance-furnace-utah-1200.webp'); --hero-bg-desktop: url('/images/maintenance-furnace-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FURNACE REPAIR · 24/7 · OREM, UTAH</p>
+                <h1>Furnace down in Orem?<br>We're driving over.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — 20 minutes south on I-15. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -220,7 +238,7 @@
                 <div class="city-facts-box">
                     <h3>What Orem Homeowners Should Know</h3>
                     <ul>
-                        <li><strong>Local expertise:</strong> Orem's diverse housing—from vintage duplexes near campus to newer family homes in surrounding subdivisions—means we service every type of system. BYU-area families know they can trust our crew. We've been keeping Orem comfortable through harsh winters and scorching summers for over nearly 30 years.</li>
+                        <li><strong>Local expertise:</strong> Orem's diverse housing—from vintage duplexes near campus to newer family homes in surrounding subdivisions—means we service every type of system. BYU-area families know they can trust our crew. We've been keeping Orem comfortable through harsh winters and scorching summers for over thirty years.</li>
                         <li><strong>Emergency availability:</strong> We're available 24/7 for furnace failures and AC breakdowns. From our Lehi headquarters, we typically respond to Orem within 20-25 minutes.</li>
                         <li><strong>Certifications & licensing:</strong> Our technicians are NATE-certified, EPA-certified, and hold Utah HVAC license #96-324211-550. We maintain the highest standards on every job.</li>
                     </ul>
@@ -228,7 +246,7 @@
 
                 <h3>Why Choose Air Express for Furnace Repair in Orem?</h3>
                 <ul style="line-height: 1.8;">
-                    <li>nearly 30 years serving Orem and surrounding communities since 1996</li>
+                    <li>thirty years serving Orem and surrounding communities since 1996</li>
                     <li>NATE-certified technicians with deep heating and cooling expertise</li>
                     <li>4.9-star rating from 280+ satisfied Orem neighbors</li>
                     <li>Same-day service available—we're minutes away from Orem</li>
@@ -270,7 +288,7 @@
                     </details>
                     <details>
                         <summary><strong>What makes Air Express different for Furnace Repair in Orem?</strong></summary>
-                        <p>We're not a call center—we're your neighbors. nearly 30 years in Orem. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Orem's unique HVAC challenges and deliver solutions that last.</p>
+                        <p>We're not a call center—we're your neighbors. thirty years in Orem. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Orem's unique HVAC challenges and deliver solutions that last.</p>
                     </details>
                 </div>
 
@@ -280,12 +298,20 @@
         </section>
 
         <!-- CTA SECTION -->
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Need Furnace Repair in Orem?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">Get a free estimate today. No obligation. Transparent pricing.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · OREM</p>
+                <h2>Tell us what's going on with your heat.</h2>
+                <p>We'll come take a look, diagnose the real problem, and give you a written estimate before any work starts. If it's an emergency, call — we answer the phone and we're on the way.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -335,76 +361,6 @@
         <div class="footer-bottom">
             <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-
-    <!-- Navigation Script -->
-    <script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                var expanded = nav.classList.contains('active');
-                toggle.setAttribute('aria-expanded', expanded);
-            });
-        }
-    })();
-    </script>
-    
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
-        </div>
-    </footer>
 <button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>

--- a/furnace-repair-sandy-ut.html
+++ b/furnace-repair-sandy-ut.html
@@ -102,7 +102,7 @@
                 "name": "What makes Air Express the best choice for Furnace Repair in Sandy?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "nearly 30 years serving Sandy and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
+                    "text": "thirty years serving Sandy and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
                 }
             }
         ]
@@ -199,14 +199,32 @@
         </section>
 
         <!-- HERO -->
-        <section class="hero geo-hero" aria-label="Hero section">
-            <div class="hero-content">
-                <h1>Expert Furnace Repair in Sandy, UT</h1>
-                <p class="tagline">NATE-Certified Technicians • Same-Day Service • Nearly 30 Years of Local Expertise</p>
-                <p>Air Express provides professional Furnace Repair throughout Sandy. Licensed, certified, and ready to solve your HVAC challenges. Call (801) 766-8585 for a free estimate—we're just 35-40 minutes away.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/maintenance-furnace-utah-1200.webp'); --hero-bg-desktop: url('/images/maintenance-furnace-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FURNACE REPAIR · 24/7 · SANDY, UTAH</p>
+                <h1>Furnace down in Sandy?<br>We're driving over.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — 25 minutes up I-15. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -228,7 +246,7 @@
 
                 <h3>Why Choose Air Express for Furnace Repair in Sandy?</h3>
                 <ul style="line-height: 1.8;">
-                    <li>nearly 30 years serving Sandy and surrounding communities since 1996</li>
+                    <li>thirty years serving Sandy and surrounding communities since 1996</li>
                     <li>NATE-certified technicians with deep heating and cooling expertise</li>
                     <li>4.9-star rating from 280+ satisfied Sandy neighbors</li>
                     <li>Same-day service available—we're minutes away from Sandy</li>
@@ -270,7 +288,7 @@
                     </details>
                     <details>
                         <summary><strong>What makes Air Express different for Furnace Repair in Sandy?</strong></summary>
-                        <p>We're not a call center—we're your neighbors. nearly 30 years in Sandy. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Sandy's unique HVAC challenges and deliver solutions that last.</p>
+                        <p>We're not a call center—we're your neighbors. thirty years in Sandy. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Sandy's unique HVAC challenges and deliver solutions that last.</p>
                     </details>
                 </div>
 
@@ -280,12 +298,20 @@
         </section>
 
         <!-- CTA SECTION -->
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Need Furnace Repair in Sandy?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">Get a free estimate today. No obligation. Transparent pricing.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · SANDY</p>
+                <h2>Tell us what's going on with your heat.</h2>
+                <p>We'll come take a look, diagnose the real problem, and give you a written estimate before any work starts. If it's an emergency, call — we answer the phone and we're on the way.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -335,76 +361,6 @@
         <div class="footer-bottom">
             <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-
-    <!-- Navigation Script -->
-    <script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                var expanded = nav.classList.contains('active');
-                toggle.setAttribute('aria-expanded', expanded);
-            });
-        }
-    })();
-    </script>
-    
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
-        </div>
-    </footer>
 <button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>

--- a/furnace-repair-saratoga-springs-ut.html
+++ b/furnace-repair-saratoga-springs-ut.html
@@ -55,7 +55,7 @@
             {"@type": "Question", "name": "Do you service both newer and older furnaces in Saratoga Springs?", "acceptedAnswer": {"@type": "Answer", "text": "Yes! Saratoga Springs has a mix of home ages. We service all furnace types and brands with equal expertise."}},
             {"@type": "Question", "name": "How does humidity affect furnace lifespan?", "acceptedAnswer": {"@type": "Answer", "text": "Higher humidity near Utah Lake can affect furnace components. Regular maintenance helps protect your system from moisture-related issues."}},
             {"@type": "Question", "name": "Are you licensed and certified?", "acceptedAnswer": {"@type": "Answer", "text": "All technicians are NATE-certified, EPA-certified, and hold Utah license #96-324211-550."}},
-            {"@type": "Question", "name": "What makes Air Express different?", "acceptedAnswer": {"@type": "Answer", "text": "nearly 30 years serving Saratoga Springs. 15-minute response. 24/7 emergency service. 4.9-star reviews. Transparent pricing. We're your neighbors."}}
+            {"@type": "Question", "name": "What makes Air Express different?", "acceptedAnswer": {"@type": "Answer", "text": "thirty years serving Saratoga Springs. 15-minute response. 24/7 emergency service. 4.9-star reviews. Transparent pricing. We're your neighbors."}}
         ]
     }
     </script>    <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -138,14 +138,32 @@
             </div>
         </section>
 
-        <section class="hero geo-hero">
-            <div class="hero-content">
-                <h1>Expert Furnace Repair in Saratoga Springs, UT</h1>
-                <p class="tagline">NATE-Certified Technicians • Emergency Service 24/7 • 15-Minute Response</p>
-                <p>Air Express provides professional furnace repair for Saratoga Springs homes. When your heating fails on a cold winter night, we're here 24/7. Licensed, certified, and just 15 minutes away from your home. Call (801) 766-8585 for emergency service anytime.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/maintenance-furnace-utah-1200.webp'); --hero-bg-desktop: url('/images/maintenance-furnace-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FURNACE REPAIR · 24/7 · SARATOGA SPRINGS, UTAH</p>
+                <h1>Furnace down in Saratoga Springs?<br>We're driving over.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — 15 minutes west of Lehi. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -167,7 +185,7 @@
 
                 <h3>Why Choose Air Express for Furnace Repair in Saratoga Springs?</h3>
                 <ul style="line-height: 1.8;">
-                    <li>nearly 30 years serving Saratoga Springs and Utah Valley</li>
+                    <li>thirty years serving Saratoga Springs and Utah Valley</li>
                     <li>NATE-certified technicians</li>
                     <li>4.9-star rating from 280+ satisfied families</li>
                     <li>15-minute response time</li>
@@ -218,12 +236,20 @@
             </div>
         </section>
 
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Need Emergency Furnace Repair in Saratoga Springs?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">24/7 service. 15-minute response. Free estimates.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · SARATOGA SPRINGS</p>
+                <h2>Tell us what's going on with your heat.</h2>
+                <p>We'll come take a look, diagnose the real problem, and give you a written estimate before any work starts. If it's an emergency, call — we answer the phone and we're on the way.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -268,70 +294,6 @@
         </div>
         <div class="footer-bottom">
             <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved.</p>
-        </div>
-<script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                toggle.setAttribute('aria-expanded', nav.classList.contains('active'));
-            });
-        }
-    })();
-    </script>
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
     </footer>
 <button class="back-to-top" aria-label="Back to top">

--- a/heating-installation-eagle-mountain-ut.html
+++ b/heating-installation-eagle-mountain-ut.html
@@ -140,14 +140,32 @@
             </div>
         </section>
 
-        <section class="hero geo-hero">
-            <div class="hero-content">
-                <h1>Heating Installation in Eagle Mountain, UT</h1>
-                <p class="tagline">Furnaces • Heat Pumps • High-Efficiency Systems • New Construction Specialist</p>
-                <p>Air Express provides expert heating installation for Eagle Mountain homes. Whether installing a new furnace, upgrading to a heat pump, or commissioning systems in new construction, we deliver professional results. Free estimates. NATE-certified. Call (801) 766-8585.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/maintenance-furnace-utah-1200.webp'); --hero-bg-desktop: url('/images/maintenance-furnace-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">HEATING INSTALL · DONE RIGHT · EAGLE MOUNTAIN, UTAH</p>
+                <h1>A new furnace in Eagle Mountain,<br>installed the right way.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — 15 minutes west of Lehi. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -169,7 +187,7 @@
 
                 <h3>Why Choose Air Express for Heating Installation in Eagle Mountain?</h3>
                 <ul style="line-height: 1.8;">
-                    <li>nearly 30 years serving Eagle Mountain and Utah Valley</li>
+                    <li>thirty years serving Eagle Mountain and Utah Valley</li>
                     <li>NATE-certified technicians with installation expertise</li>
                     <li>4.9-star rating from 280+ satisfied families</li>
                     <li>Free in-home estimates with detailed pricing</li>
@@ -215,12 +233,20 @@
             </div>
         </section>
 
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Ready for Heating Installation in Eagle Mountain?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">Get a free estimate today. No obligation.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · EAGLE MOUNTAIN</p>
+                <h2>Tell us what's going on with your heat.</h2>
+                <p>We'll come take a look, diagnose the real problem, and give you a written estimate before any work starts. If it's an emergency, call — we answer the phone and we're on the way.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -265,70 +291,6 @@
         </div>
         <div class="footer-bottom">
             <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved.</p>
-        </div>
-<script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                toggle.setAttribute('aria-expanded', nav.classList.contains('active'));
-            });
-        }
-    })();
-    </script>
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
     </footer>
 <button class="back-to-top" aria-label="Back to top">

--- a/heating-installation-lehi-ut.html
+++ b/heating-installation-lehi-ut.html
@@ -102,7 +102,7 @@
                 "name": "What makes Air Express the best choice for Heating Installation in Lehi?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "nearly 30 years serving Lehi and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
+                    "text": "thirty years serving Lehi and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
                 }
             }
         ]
@@ -199,14 +199,32 @@
         </section>
 
         <!-- HERO -->
-        <section class="hero geo-hero" aria-label="Hero section">
-            <div class="hero-content">
-                <h1>Expert Heating Installation in Lehi, UT</h1>
-                <p class="tagline">NATE-Certified Technicians • Same-Day Service • Nearly 30 Years of Local Expertise</p>
-                <p>Air Express provides professional Heating Installation throughout Lehi. Licensed, certified, and ready to solve your HVAC challenges. Call (801) 766-8585 for a free estimate—we're just 15-20 minutes away.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/maintenance-furnace-utah-1200.webp'); --hero-bg-desktop: url('/images/maintenance-furnace-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">HEATING INSTALL · DONE RIGHT · LEHI, UTAH</p>
+                <h1>A new furnace in Lehi,<br>installed the right way.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — our hometown since 1996. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -228,7 +246,7 @@
 
                 <h3>Why Choose Air Express for Heating Installation in Lehi?</h3>
                 <ul style="line-height: 1.8;">
-                    <li>nearly 30 years serving Lehi and surrounding communities since 1996</li>
+                    <li>thirty years serving Lehi and surrounding communities since 1996</li>
                     <li>NATE-certified technicians with deep heating and cooling expertise</li>
                     <li>4.9-star rating from 280+ satisfied Lehi neighbors</li>
                     <li>Same-day service available—we're minutes away from Lehi</li>
@@ -270,7 +288,7 @@
                     </details>
                     <details>
                         <summary><strong>What makes Air Express different for Heating Installation in Lehi?</strong></summary>
-                        <p>We're not a call center—we're your neighbors. nearly 30 years in Lehi. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Lehi's unique HVAC challenges and deliver solutions that last.</p>
+                        <p>We're not a call center—we're your neighbors. thirty years in Lehi. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Lehi's unique HVAC challenges and deliver solutions that last.</p>
                     </details>
                 </div>
 
@@ -280,12 +298,20 @@
         </section>
 
         <!-- CTA SECTION -->
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Need Heating Installation in Lehi?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">Get a free estimate today. No obligation. Transparent pricing.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · LEHI</p>
+                <h2>Tell us what's going on with your heat.</h2>
+                <p>We'll come take a look, diagnose the real problem, and give you a written estimate before any work starts. If it's an emergency, call — we answer the phone and we're on the way.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -335,76 +361,6 @@
         <div class="footer-bottom">
             <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-
-    <!-- Navigation Script -->
-    <script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                var expanded = nav.classList.contains('active');
-                toggle.setAttribute('aria-expanded', expanded);
-            });
-        }
-    })();
-    </script>
-    
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
-        </div>
-    </footer>
 <button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>

--- a/heating-installation-orem-ut.html
+++ b/heating-installation-orem-ut.html
@@ -102,7 +102,7 @@
                 "name": "What makes Air Express the best choice for Heating Installation in Orem?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "nearly 30 years serving Orem and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
+                    "text": "thirty years serving Orem and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
                 }
             }
         ]
@@ -199,14 +199,32 @@
         </section>
 
         <!-- HERO -->
-        <section class="hero geo-hero" aria-label="Hero section">
-            <div class="hero-content">
-                <h1>Expert Heating Installation in Orem, UT</h1>
-                <p class="tagline">NATE-Certified Technicians • Same-Day Service • Nearly 30 Years of Local Expertise</p>
-                <p>Air Express provides professional Heating Installation throughout Orem. Licensed, certified, and ready to solve your HVAC challenges. Call (801) 766-8585 for a free estimate—we're just 20-25 minutes away.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/maintenance-furnace-utah-1200.webp'); --hero-bg-desktop: url('/images/maintenance-furnace-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">HEATING INSTALL · DONE RIGHT · OREM, UTAH</p>
+                <h1>A new furnace in Orem,<br>installed the right way.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — 20 minutes south on I-15. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -220,7 +238,7 @@
                 <div class="city-facts-box">
                     <h3>What Orem Homeowners Should Know</h3>
                     <ul>
-                        <li><strong>Local expertise:</strong> Orem's diverse housing—from vintage duplexes near campus to newer family homes in surrounding subdivisions—means we service every type of system. BYU-area families know they can trust our crew. We've been keeping Orem comfortable through harsh winters and scorching summers for over nearly 30 years.</li>
+                        <li><strong>Local expertise:</strong> Orem's diverse housing—from vintage duplexes near campus to newer family homes in surrounding subdivisions—means we service every type of system. BYU-area families know they can trust our crew. We've been keeping Orem comfortable through harsh winters and scorching summers for over thirty years.</li>
                         <li><strong>Emergency availability:</strong> We're available 24/7 for furnace failures and AC breakdowns. From our Lehi headquarters, we typically respond to Orem within 20-25 minutes.</li>
                         <li><strong>Certifications & licensing:</strong> Our technicians are NATE-certified, EPA-certified, and hold Utah HVAC license #96-324211-550. We maintain the highest standards on every job.</li>
                     </ul>
@@ -228,7 +246,7 @@
 
                 <h3>Why Choose Air Express for Heating Installation in Orem?</h3>
                 <ul style="line-height: 1.8;">
-                    <li>nearly 30 years serving Orem and surrounding communities since 1996</li>
+                    <li>thirty years serving Orem and surrounding communities since 1996</li>
                     <li>NATE-certified technicians with deep heating and cooling expertise</li>
                     <li>4.9-star rating from 280+ satisfied Orem neighbors</li>
                     <li>Same-day service available—we're minutes away from Orem</li>
@@ -270,7 +288,7 @@
                     </details>
                     <details>
                         <summary><strong>What makes Air Express different for Heating Installation in Orem?</strong></summary>
-                        <p>We're not a call center—we're your neighbors. nearly 30 years in Orem. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Orem's unique HVAC challenges and deliver solutions that last.</p>
+                        <p>We're not a call center—we're your neighbors. thirty years in Orem. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Orem's unique HVAC challenges and deliver solutions that last.</p>
                     </details>
                 </div>
 
@@ -280,12 +298,20 @@
         </section>
 
         <!-- CTA SECTION -->
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Need Heating Installation in Orem?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">Get a free estimate today. No obligation. Transparent pricing.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · OREM</p>
+                <h2>Tell us what's going on with your heat.</h2>
+                <p>We'll come take a look, diagnose the real problem, and give you a written estimate before any work starts. If it's an emergency, call — we answer the phone and we're on the way.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -335,76 +361,6 @@
         <div class="footer-bottom">
             <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-
-    <!-- Navigation Script -->
-    <script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                var expanded = nav.classList.contains('active');
-                toggle.setAttribute('aria-expanded', expanded);
-            });
-        }
-    })();
-    </script>
-    
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
-        </div>
-    </footer>
 <button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>

--- a/heating-installation-sandy-ut.html
+++ b/heating-installation-sandy-ut.html
@@ -102,7 +102,7 @@
                 "name": "What makes Air Express the best choice for Heating Installation in Sandy?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "nearly 30 years serving Sandy and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
+                    "text": "thirty years serving Sandy and Utah County. NATE-certified technicians. 4.9-star reviews from 280+ local families. Emergency availability. No-surprise pricing. We're not a call center—we're your neighbors."
                 }
             }
         ]
@@ -199,14 +199,32 @@
         </section>
 
         <!-- HERO -->
-        <section class="hero geo-hero" aria-label="Hero section">
-            <div class="hero-content">
-                <h1>Expert Heating Installation in Sandy, UT</h1>
-                <p class="tagline">NATE-Certified Technicians • Same-Day Service • Nearly 30 Years of Local Expertise</p>
-                <p>Air Express provides professional Heating Installation throughout Sandy. Licensed, certified, and ready to solve your HVAC challenges. Call (801) 766-8585 for a free estimate—we're just 35-40 minutes away.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/maintenance-furnace-utah-1200.webp'); --hero-bg-desktop: url('/images/maintenance-furnace-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">HEATING INSTALL · DONE RIGHT · SANDY, UTAH</p>
+                <h1>A new furnace in Sandy,<br>installed the right way.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — 25 minutes up I-15. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -228,7 +246,7 @@
 
                 <h3>Why Choose Air Express for Heating Installation in Sandy?</h3>
                 <ul style="line-height: 1.8;">
-                    <li>nearly 30 years serving Sandy and surrounding communities since 1996</li>
+                    <li>thirty years serving Sandy and surrounding communities since 1996</li>
                     <li>NATE-certified technicians with deep heating and cooling expertise</li>
                     <li>4.9-star rating from 280+ satisfied Sandy neighbors</li>
                     <li>Same-day service available—we're minutes away from Sandy</li>
@@ -270,7 +288,7 @@
                     </details>
                     <details>
                         <summary><strong>What makes Air Express different for Heating Installation in Sandy?</strong></summary>
-                        <p>We're not a call center—we're your neighbors. nearly 30 years in Sandy. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Sandy's unique HVAC challenges and deliver solutions that last.</p>
+                        <p>We're not a call center—we're your neighbors. thirty years in Sandy. NATE-certified technicians. 4.9-star reviews from local families. Emergency availability. Transparent pricing. We understand Sandy's unique HVAC challenges and deliver solutions that last.</p>
                     </details>
                 </div>
 
@@ -280,12 +298,20 @@
         </section>
 
         <!-- CTA SECTION -->
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Need Heating Installation in Sandy?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">Get a free estimate today. No obligation. Transparent pricing.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · SANDY</p>
+                <h2>Tell us what's going on with your heat.</h2>
+                <p>We'll come take a look, diagnose the real problem, and give you a written estimate before any work starts. If it's an emergency, call — we answer the phone and we're on the way.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -335,76 +361,6 @@
         <div class="footer-bottom">
             <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-
-    <!-- Navigation Script -->
-    <script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                var expanded = nav.classList.contains('active');
-                toggle.setAttribute('aria-expanded', expanded);
-            });
-        }
-    })();
-    </script>
-    
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
-        </div>
-    </footer>
 <button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>

--- a/heating-installation-saratoga-springs-ut.html
+++ b/heating-installation-saratoga-springs-ut.html
@@ -118,14 +118,32 @@
             </div>
         </section>
 
-        <section class="hero geo-hero">
-            <div class="hero-content">
-                <h1>Heating Installation in Saratoga Springs, UT</h1>
-                <p class="tagline">Furnaces • Heat Pumps • High-Efficiency Systems • Professional Installation</p>
-                <p>Air Express provides expert heating installation for Saratoga Springs homes. Whether installing a new furnace, upgrading to a heat pump, or replacing an aging system, we deliver professional results. Free estimates. NATE-certified. Call (801) 766-8585.</p>
-                <div class="hero-ctas">
-                    <a role="menuitem" href="contact.html" class="primary">Schedule Your Free Estimate</a>
-                    <a role="menuitem" href="tel:+18017668585" class="secondary">Call Now: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/maintenance-furnace-utah-1200.webp'); --hero-bg-desktop: url('/images/maintenance-furnace-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">HEATING INSTALL · DONE RIGHT · SARATOGA SPRINGS, UTAH</p>
+                <h1>A new furnace in Saratoga Springs,<br>installed the right way.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — 15 minutes west of Lehi. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
@@ -147,7 +165,7 @@
 
                 <h3>Why Choose Air Express for Heating Installation?</h3>
                 <ul style="line-height: 1.8;">
-                    <li>nearly 30 years serving Saratoga Springs and Utah Valley</li>
+                    <li>thirty years serving Saratoga Springs and Utah Valley</li>
                     <li>NATE-certified installation technicians</li>
                     <li>4.9-star rating from 280+ satisfied families</li>
                     <li>Free in-home estimates with transparent pricing</li>
@@ -193,12 +211,20 @@
             </div>
         </section>
 
-        <section class="cta-section" style="background: linear-gradient(135deg, #8B4513 0%, #A3432F 100%); color: white; padding: 60px 20px; text-align: center;">
-            <h2 style="color: white; margin-bottom: 20px;">Ready for Heating Installation in Saratoga Springs?</h2>
-            <p style="font-size: 18px; margin-bottom: 30px;">Get a free estimate today. No obligation.</p>
-            <div style="display: flex; gap: 15px; justify-content: center; flex-wrap: wrap;">
-                <a href="contact.html" class="cta-btn" style="background: white; color: #8B4513;">Request Free Estimate</a>
-                <a href="tel:+18017668585" class="cta-btn" style="border: 2px solid white; color: white;">Call (801) 766-8585</a>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · SARATOGA SPRINGS</p>
+                <h2>Tell us what's going on with your heat.</h2>
+                <p>We'll come take a look, diagnose the real problem, and give you a written estimate before any work starts. If it's an emergency, call — we answer the phone and we're on the way.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
         </section>
     </main>
@@ -214,70 +240,6 @@
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom"><p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved.</p></div>
-<script>
-    (function() {
-        var toggle = document.querySelector('.nav-toggle');
-        var nav = document.querySelector('header nav');
-        if (toggle && nav) {
-            toggle.addEventListener('click', function(e) {
-                e.stopPropagation();
-                nav.classList.toggle('active');
-                toggle.setAttribute('aria-expanded', nav.classList.contains('active'));
-            });
-        }
-    })();
-    </script>
-    <footer role="contentinfo">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h3>License #96-324211-550 | Contact Us</h3>
-                <p><strong>(801) 766-8585</strong></p>
-                <p>628 E State St Ste 1, Lehi, UT 84043</p>
-                <p><a role="menuitem" href="contact.html">Get a Free Estimate</a></p>
-                <p><a role="menuitem" href="emergency.html">Emergency Service</a></p>
-            </div>
-            <div class="footer-section">
-                <h4>Services</h4>
-                <a role="menuitem" href="ac-services.html">Air Conditioning</a>
-                <a role="menuitem" href="heat-pump.html">Heating & Heat Pumps</a>
-                <a role="menuitem" href="ventilation.html">Air Quality</a>
-                <a role="menuitem" href="ductwork.html">Ductwork</a>
-                            <a role="menuitem" href="gas-lines.html">Gas Lines</a>
-                <a role="menuitem" href="thermostats.html">Thermostats</a>
-            </div>
-            <div class="footer-section">
-                <h4>Offerings</h4>
-                <a role="menuitem" href="residential.html">Residential</a>
-                <a role="menuitem" href="commercial.html">Commercial</a>
-                <a role="menuitem" href="multifamily.html">Multifamily</a>
-                <a role="menuitem" href="service-areas.html">Service Areas</a>
-                <a role="menuitem" href="reviews.html">Reviews</a>
-            </div>
-            <div class="footer-section">
-                <h4>Our Story</h4>
-                <a role="menuitem" href="about.html">About Air Express</a>
-                <a role="menuitem" href="careers.html">Careers</a>
-                <a role="menuitem" href="resources.html">Resources & Tips</a>
-                <a role="menuitem" href="faq.html">FAQ</a>
-                <a role="menuitem" href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a role="menuitem" href="/blog/hvac-cost-guide.html">Cost Guide</a>
-                <a role="menuitem" href="specials.html">Seasonal Specials</a>
-                <a role="menuitem" href="financing.html">Financing</a>
-            </div>
-        </div>
-        <div class="social-icons">
-            <a role="menuitem" href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
-            <a role="menuitem" href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
-            <a role="menuitem" href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
-            <a role="menuitem" href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
-        </div>
-        <div class="payment-options">
-            <span>Payment Options:</span>
-            <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
-        </div>
-        <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a role="menuitem" href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a role="menuitem" href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
-        </div>
     </footer>
 <button class="back-to-top" aria-label="Back to top"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="18 15 12 9 6 15"></polyline></svg></button>
 <script src="nav.js" defer></script>

--- a/heating-repair-lehi-ut.html
+++ b/heating-repair-lehi-ut.html
@@ -80,24 +80,51 @@
     </header>
 
     <main id="main" tabindex="-1">
-        <section class="service-hero">
-            <div class="hero-content">
-                <h1>Heating Repair In Lehi, UT</h1>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/maintenance-furnace-utah-1200.webp'); --hero-bg-desktop: url('/images/maintenance-furnace-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">HEATING REPAIR · 24/7 · LEHI, UTAH</p>
+                <h1>Heat out in Lehi?<br>We'll warm the house back up.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — our hometown since 1996. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
+                </div>
             </div>
         </section>
 
-        <section class="content-section">
-            <div class="container">
-                <h2>Expert Heating Repair Services in Lehi, Utah</h2>
-                <p><strong>Heating Repair In Lehi, UT and Surrounding Areas</strong></p><p>When your heating system breaks down, Air Express HVAC is here to help. Our experienced technicians provide fast, reliable heating repair services in Lehi and surrounding Utah communities.</p>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · LEHI</p>
+                <h2>Tell us what's going on with your heat.</h2>
+                <p>We'll come take a look, diagnose the real problem, and give you a written estimate before any work starts. If it's an emergency, call — we answer the phone and we're on the way.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
-        </section>
-
-        <section class="big-cta">
-            <h2>Ready to Get Started?</h2>
-            <p>Contact Us For Heating Repair In Lehi, UT</p>
-            <a href="contact.html" class="cta-btn">Contact Us Today</a>
-            <p style="margin-top:1rem;"><a href="tel:+18017668585" style="color:#fff;">(801) 766-8585</a></p>
         </section>
     </main>
 

--- a/heating-services-saratoga-springs-ut.html
+++ b/heating-services-saratoga-springs-ut.html
@@ -80,24 +80,51 @@
     </header>
 
     <main id="main" tabindex="-1">
-        <section class="service-hero">
-            <div class="hero-content">
-                <h1>Heating Services In Saratoga Springs, UT</h1>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/maintenance-furnace-utah-1200.webp'); --hero-bg-desktop: url('/images/maintenance-furnace-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">HEATING · FULL SERVICE · SARATOGA SPRINGS, UTAH</p>
+                <h1>Heating you can count on<br>all winter in Saratoga Springs.</h1>
+                <p class="service-hero-sub">Family-owned since 1996 and based in Lehi — 15 minutes west of Lehi. We show up when we say we will, explain what's going on, and fix it without selling you parts you don't need.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
+                </div>
             </div>
         </section>
 
-        <section class="content-section">
-            <div class="container">
-                <h2>Expert Heating Services in Saratoga Springs, Utah</h2>
-                <p><strong>Heating Services In Saratoga Springs, UT and Surrounding Areas</strong></p><p>Air Express Heating and Air Conditioning provides professional heating services to Saratoga Springs, UT and surrounding communities. From furnace repair to heating system installation, our experienced team keeps your home warm and comfortable.</p>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · SARATOGA SPRINGS</p>
+                <h2>Tell us what's going on with your heat.</h2>
+                <p>We'll come take a look, diagnose the real problem, and give you a written estimate before any work starts. If it's an emergency, call — we answer the phone and we're on the way.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
-        </section>
-
-        <section class="big-cta">
-            <h2>Ready to Get Started?</h2>
-            <p>Contact Us For Heating Services In Saratoga Springs, UT</p>
-            <a href="contact.html" class="cta-btn">Contact Us Today</a>
-            <p style="margin-top:1rem;"><a href="tel:+18017668585" style="color:#fff;">(801) 766-8585</a></p>
         </section>
     </main>
 

--- a/service-area-alpine.html
+++ b/service-area-alpine.html
@@ -102,57 +102,50 @@
     </header>
 
     <main id="main" tabindex="-1">
-<section class="hero">
-            <div class="hero-content">
-                <h1>HVAC Services in Alpine, Utah</h1>
-                <p>Professional heating and cooling services for Alpine homes and businesses.</p>
-                <div class="hero-ctas">
-                    <a href="contact.html" class="primary">Get Free Estimate</a>
-                    <a href="tel:+18017668585" class="secondary">Call: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/trust-porch-utah-1200.webp'); --hero-bg-desktop: url('/images/trust-porch-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FAMILY-OWNED · SINCE 1996 · ALPINE, UTAH</p>
+                <h1>Your neighbors in heating<br>&amp; cooling — Alpine, UT.</h1>
+                <p class="service-hero-sub">Same family, same crew, same phone number since 1996. We've been keeping Alpine homes comfortable for three generations — and we'd like to be your heating and cooling company too.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
-        <section class="section">
-            <h2 class="section-title">Alpine HVAC Services</h2>
-            <div class="content">
-                <h2>Your Local HVAC Experts in Alpine</h2>
-                <p>Air Express HVAC proudly serves the Alpine community with expert heating and cooling services. Whether you need AC installation for summer comfort, furnace repair for winter warmth, or regular maintenance to keep your system running smoothly, our licensed and insured technicians are here to help.</p>
-                <h3 style="font-family: Georgia, serif; color: var(--primary); font-size: 24px; margin-top: 30px; margin-bottom: 15px;">Services Available in Alpine:</h3>
-                <ul style="list-style-position: inside; line-height: 1.8;">
-                    <li><strong>AC Installation & Repair</strong> - Beat Alpine's hot summers with reliable air conditioning</li>
-                    <li><strong>Furnace Services</strong> - Dependable heating for Alpine's cold winters</li>
-                    <li><strong>Heat Pump Installation</strong> - Efficient year-round comfort systems</li>
-                    <li><strong>Maintenance Plans</strong> - Keep your system running smoothly all year</li>
-                    <li><strong>Emergency Service</strong> - 24/7 availability when you need us most</li>
-                    <li><strong>Air Quality Solutions</strong> - Healthier indoor air for your Alpine home</li>
-                </ul>
-                <p style="margin-top: 20px;">With nearly 30 years of experience serving Utah County, Air Express HVAC understands Alpine's unique climate challenges. We're committed to providing fast, honest service backed by expert technicians and fair pricing.</p>
-            </div>
-        </section>
-        <section class="why-us">
-            <h2 class="section-title">Why Choose Air Express for Alpine?</h2>
-            <div class="why-us-grid">
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12c0 5.33 3.95 9.75 9 10.92V22h2v-2.08c5.05-1.17 9-5.59 9-10.92 0-5.52-4.48-10-10-10zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-13c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5z"/></svg></span>
-                    <h3>Local Experts</h3>
-                    <p>Serving Alpine for nearly 30 years with local knowledge and expertise</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg></span>
-                    <h4>Fast Response</h4>
-                    <p>Quick service with 24/7 emergency availability for Alpine</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></span>
-                    <h4>Trusted Service</h4>
-                    <p>4.9 rating from 280+ Alpine families and businesses</p>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · ALPINE</p>
+                <h2>Need us out? Just tell us what's wrong.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No call center, no pressure, no upsell.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
                 </div>
             </div>
-        </section>
-        <section class="big-cta">
-            <h2>Ready for Expert HVAC Service in Alpine?</h2>
-            <p>Contact Air Express HVAC today for fast, professional service.</p>
-            <a href="contact.html" class="cta-btn" style="display: inline-block; background: white; color: var(--secondary); border-color: white; margin-top: 10px;">Request Free Estimate</a>
         </section>
     </main>
 

--- a/service-area-american-fork.html
+++ b/service-area-american-fork.html
@@ -102,57 +102,50 @@
     </header>
 
     <main id="main" tabindex="-1">
-<section class="hero">
-            <div class="hero-content">
-                <h1>HVAC Services in American Fork, Utah</h1>
-                <p>Professional heating and cooling services for American Fork homes and businesses.</p>
-                <div class="hero-ctas">
-                    <a href="contact.html" class="primary">Get Free Estimate</a>
-                    <a href="tel:+18017668585" class="secondary">Call: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/trust-porch-utah-1200.webp'); --hero-bg-desktop: url('/images/trust-porch-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FAMILY-OWNED · SINCE 1996 · AMERICAN FORK, UTAH</p>
+                <h1>Your neighbors in heating<br>&amp; cooling — American Fork, UT.</h1>
+                <p class="service-hero-sub">Same family, same crew, same phone number since 1996. We've been keeping American Fork homes comfortable for three generations — and we'd like to be your heating and cooling company too.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
-        <section class="section">
-            <h2 class="section-title">American Fork HVAC Services</h2>
-            <div class="content">
-                <h2>Your Local HVAC Experts in American Fork</h2>
-                <p>Air Express HVAC proudly serves the American Fork community with expert heating and cooling services. Whether you need AC installation for summer comfort, furnace repair for winter warmth, or regular maintenance to keep your system running smoothly, our licensed and insured technicians are here to help.</p>
-                <h3 style="font-family: Georgia, serif; color: var(--primary); font-size: 24px; margin-top: 30px; margin-bottom: 15px;">Services Available in American Fork:</h3>
-                <ul style="list-style-position: inside; line-height: 1.8;">
-                    <li><strong>AC Installation & Repair</strong> - Beat American Fork's hot summers with reliable air conditioning</li>
-                    <li><strong>Furnace Services</strong> - Dependable heating for American Fork's cold winters</li>
-                    <li><strong>Heat Pump Installation</strong> - Efficient year-round comfort systems</li>
-                    <li><strong>Maintenance Plans</strong> - Keep your system running smoothly all year</li>
-                    <li><strong>Emergency Service</strong> - 24/7 availability when you need us most</li>
-                    <li><strong>Air Quality Solutions</strong> - Healthier indoor air for your American Fork home</li>
-                </ul>
-                <p style="margin-top: 20px;">With nearly 30 years of experience serving Utah County, Air Express HVAC understands American Fork's unique climate challenges. We're committed to providing fast, honest service backed by expert technicians and fair pricing.</p>
-            </div>
-        </section>
-        <section class="why-us">
-            <h2 class="section-title">Why Choose Air Express for American Fork?</h2>
-            <div class="why-us-grid">
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12c0 5.33 3.95 9.75 9 10.92V22h2v-2.08c5.05-1.17 9-5.59 9-10.92 0-5.52-4.48-10-10-10zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-13c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5z"/></svg></span>
-                    <h3>Local Experts</h3>
-                    <p>Serving American Fork for nearly 30 years with local knowledge and expertise</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg></span>
-                    <h4>Fast Response</h4>
-                    <p>Quick service with 24/7 emergency availability for American Fork</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></span>
-                    <h4>Trusted Service</h4>
-                    <p>4.9 rating from 280+ American Fork families and businesses</p>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · AMERICAN FORK</p>
+                <h2>Need us out? Just tell us what's wrong.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No call center, no pressure, no upsell.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
                 </div>
             </div>
-        </section>
-        <section class="big-cta">
-            <h2>Ready for Expert HVAC Service in American Fork?</h2>
-            <p>Contact Air Express HVAC today for fast, professional service.</p>
-            <a href="contact.html" class="cta-btn" style="display: inline-block; background: white; color: var(--secondary); border-color: white; margin-top: 10px;">Request Free Estimate</a>
         </section>
     </main>
 

--- a/service-area-bluffdale.html
+++ b/service-area-bluffdale.html
@@ -102,57 +102,50 @@
     </header>
 
     <main id="main" tabindex="-1">
-<section class="hero">
-            <div class="hero-content">
-                <h1>HVAC Services in Bluffdale, Utah</h1>
-                <p>Professional heating and cooling services for Bluffdale homes and businesses.</p>
-                <div class="hero-ctas">
-                    <a href="contact.html" class="primary">Get Free Estimate</a>
-                    <a href="tel:+18017668585" class="secondary">Call: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/trust-porch-utah-1200.webp'); --hero-bg-desktop: url('/images/trust-porch-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FAMILY-OWNED · SINCE 1996 · BLUFFDALE, UTAH</p>
+                <h1>Your neighbors in heating<br>&amp; cooling — Bluffdale, UT.</h1>
+                <p class="service-hero-sub">Same family, same crew, same phone number since 1996. We've been keeping Bluffdale homes comfortable for three generations — and we'd like to be your heating and cooling company too.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
-        <section class="section">
-            <h2 class="section-title">Bluffdale HVAC Services</h2>
-            <div class="content">
-                <h2>Your Local HVAC Experts in Bluffdale</h2>
-                <p>Air Express HVAC proudly serves the Bluffdale community with expert heating and cooling services. Whether you need AC installation for summer comfort, furnace repair for winter warmth, or regular maintenance to keep your system running smoothly, our licensed and insured technicians are here to help.</p>
-                <h3 style="font-family: Georgia, serif; color: var(--primary); font-size: 24px; margin-top: 30px; margin-bottom: 15px;">Services Available in Bluffdale:</h3>
-                <ul style="list-style-position: inside; line-height: 1.8;">
-                    <li><strong>AC Installation & Repair</strong> - Beat Bluffdale's hot summers with reliable air conditioning</li>
-                    <li><strong>Furnace Services</strong> - Dependable heating for Bluffdale's cold winters</li>
-                    <li><strong>Heat Pump Installation</strong> - Efficient year-round comfort systems</li>
-                    <li><strong>Maintenance Plans</strong> - Keep your system running smoothly all year</li>
-                    <li><strong>Emergency Service</strong> - 24/7 availability when you need us most</li>
-                    <li><strong>Air Quality Solutions</strong> - Healthier indoor air for your Bluffdale home</li>
-                </ul>
-                <p style="margin-top: 20px;">With nearly 30 years of experience serving Utah County, Air Express HVAC understands Bluffdale's unique climate challenges. We're committed to providing fast, honest service backed by expert technicians and fair pricing.</p>
-            </div>
-        </section>
-        <section class="why-us">
-            <h2 class="section-title">Why Choose Air Express for Bluffdale?</h2>
-            <div class="why-us-grid">
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12c0 5.33 3.95 9.75 9 10.92V22h2v-2.08c5.05-1.17 9-5.59 9-10.92 0-5.52-4.48-10-10-10zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-13c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5z"/></svg></span>
-                    <h3>Local Experts</h3>
-                    <p>Serving Bluffdale for nearly 30 years with local knowledge and expertise</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg></span>
-                    <h4>Fast Response</h4>
-                    <p>Quick service with 24/7 emergency availability for Bluffdale</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></span>
-                    <h4>Trusted Service</h4>
-                    <p>4.9 rating from 280+ Bluffdale families and businesses</p>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · BLUFFDALE</p>
+                <h2>Need us out? Just tell us what's wrong.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No call center, no pressure, no upsell.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
                 </div>
             </div>
-        </section>
-        <section class="big-cta">
-            <h2>Ready for Expert HVAC Service in Bluffdale?</h2>
-            <p>Contact Air Express HVAC today for fast, professional service.</p>
-            <a href="contact.html" class="cta-btn" style="display: inline-block; background: white; color: var(--secondary); border-color: white; margin-top: 10px;">Request Free Estimate</a>
         </section>
     </main>
 

--- a/service-area-draper.html
+++ b/service-area-draper.html
@@ -102,57 +102,50 @@
     </header>
 
     <main id="main" tabindex="-1">
-<section class="hero">
-            <div class="hero-content">
-                <h1>HVAC Services in Draper, Utah</h1>
-                <p>Professional heating and cooling services for Draper homes and businesses.</p>
-                <div class="hero-ctas">
-                    <a href="contact.html" class="primary">Get Free Estimate</a>
-                    <a href="tel:+18017668585" class="secondary">Call: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/trust-porch-utah-1200.webp'); --hero-bg-desktop: url('/images/trust-porch-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FAMILY-OWNED · SINCE 1996 · DRAPER, UTAH</p>
+                <h1>Your neighbors in heating<br>&amp; cooling — Draper, UT.</h1>
+                <p class="service-hero-sub">Same family, same crew, same phone number since 1996. We've been keeping Draper homes comfortable for three generations — and we'd like to be your heating and cooling company too.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
-        <section class="section">
-            <h2 class="section-title">Draper HVAC Services</h2>
-            <div class="content">
-                <h2>Your Local HVAC Experts in Draper</h2>
-                <p>Air Express HVAC proudly serves the Draper community with expert heating and cooling services. Whether you need AC installation for summer comfort, furnace repair for winter warmth, or regular maintenance to keep your system running smoothly, our licensed and insured technicians are here to help.</p>
-                <h3 style="font-family: Georgia, serif; color: var(--primary); font-size: 24px; margin-top: 30px; margin-bottom: 15px;">Services Available in Draper:</h3>
-                <ul style="list-style-position: inside; line-height: 1.8;">
-                    <li><strong>AC Installation & Repair</strong> - Beat Draper's hot summers with reliable air conditioning</li>
-                    <li><strong>Furnace Services</strong> - Dependable heating for Draper's cold winters</li>
-                    <li><strong>Heat Pump Installation</strong> - Efficient year-round comfort systems</li>
-                    <li><strong>Maintenance Plans</strong> - Keep your system running smoothly all year</li>
-                    <li><strong>Emergency Service</strong> - 24/7 availability when you need us most</li>
-                    <li><strong>Air Quality Solutions</strong> - Healthier indoor air for your Draper home</li>
-                </ul>
-                <p style="margin-top: 20px;">With nearly 30 years of experience serving Utah County, Air Express HVAC understands Draper's unique climate challenges. We're committed to providing fast, honest service backed by expert technicians and fair pricing.</p>
-            </div>
-        </section>
-        <section class="why-us">
-            <h2 class="section-title">Why Choose Air Express for Draper?</h2>
-            <div class="why-us-grid">
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12c0 5.33 3.95 9.75 9 10.92V22h2v-2.08c5.05-1.17 9-5.59 9-10.92 0-5.52-4.48-10-10-10zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-13c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5z"/></svg></span>
-                    <h3>Local Experts</h3>
-                    <p>Serving Draper for nearly 30 years with local knowledge and expertise</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg></span>
-                    <h4>Fast Response</h4>
-                    <p>Quick service with 24/7 emergency availability for Draper</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></span>
-                    <h4>Trusted Service</h4>
-                    <p>4.9 rating from 280+ Draper families and businesses</p>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · DRAPER</p>
+                <h2>Need us out? Just tell us what's wrong.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No call center, no pressure, no upsell.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
                 </div>
             </div>
-        </section>
-        <section class="big-cta">
-            <h2>Ready for Expert HVAC Service in Draper?</h2>
-            <p>Contact Air Express HVAC today for fast, professional service.</p>
-            <a href="contact.html" class="cta-btn" style="display: inline-block; background: white; color: var(--secondary); border-color: white; margin-top: 10px;">Request Free Estimate</a>
         </section>
     </main>
 

--- a/service-area-eagle-mountain.html
+++ b/service-area-eagle-mountain.html
@@ -102,57 +102,50 @@
     </header>
 
     <main id="main" tabindex="-1">
-<section class="hero">
-            <div class="hero-content">
-                <h1>HVAC Services in Eagle Mountain, Utah</h1>
-                <p>Professional heating and cooling services for Eagle Mountain homes and businesses.</p>
-                <div class="hero-ctas">
-                    <a href="contact.html" class="primary">Get Free Estimate</a>
-                    <a href="tel:+18017668585" class="secondary">Call: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/trust-porch-utah-1200.webp'); --hero-bg-desktop: url('/images/trust-porch-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FAMILY-OWNED · SINCE 1996 · EAGLE MOUNTAIN, UTAH</p>
+                <h1>Your neighbors in heating<br>&amp; cooling — Eagle Mountain, UT.</h1>
+                <p class="service-hero-sub">Same family, same crew, same phone number since 1996. We've been keeping Eagle Mountain homes comfortable for three generations — and we'd like to be your heating and cooling company too.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
-        <section class="section">
-            <h2 class="section-title">Eagle Mountain HVAC Services</h2>
-            <div class="content">
-                <h2>Your Local HVAC Experts in Eagle Mountain</h2>
-                <p>Air Express HVAC proudly serves the Eagle Mountain community with expert heating and cooling services. Whether you need AC installation for summer comfort, furnace repair for winter warmth, or regular maintenance to keep your system running smoothly, our licensed and insured technicians are here to help.</p>
-                <h3 style="font-family: Georgia, serif; color: var(--primary); font-size: 24px; margin-top: 30px; margin-bottom: 15px;">Services Available in Eagle Mountain:</h3>
-                <ul style="list-style-position: inside; line-height: 1.8;">
-                    <li><strong>AC Installation & Repair</strong> - Beat Eagle Mountain's hot summers with reliable air conditioning</li>
-                    <li><strong>Furnace Services</strong> - Dependable heating for Eagle Mountain's cold winters</li>
-                    <li><strong>Heat Pump Installation</strong> - Efficient year-round comfort systems</li>
-                    <li><strong>Maintenance Plans</strong> - Keep your system running smoothly all year</li>
-                    <li><strong>Emergency Service</strong> - 24/7 availability when you need us most</li>
-                    <li><strong>Air Quality Solutions</strong> - Healthier indoor air for your Eagle Mountain home</li>
-                </ul>
-                <p style="margin-top: 20px;">With nearly 30 years of experience serving Utah County, Air Express HVAC understands Eagle Mountain's unique climate challenges. We're committed to providing fast, honest service backed by expert technicians and fair pricing.</p>
-            </div>
-        </section>
-        <section class="why-us">
-            <h2 class="section-title">Why Choose Air Express for Eagle Mountain?</h2>
-            <div class="why-us-grid">
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12c0 5.33 3.95 9.75 9 10.92V22h2v-2.08c5.05-1.17 9-5.59 9-10.92 0-5.52-4.48-10-10-10zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-13c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5z"/></svg></span>
-                    <h3>Local Experts</h3>
-                    <p>Serving Eagle Mountain for nearly 30 years with local knowledge and expertise</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg></span>
-                    <h4>Fast Response</h4>
-                    <p>Quick service with 24/7 emergency availability for Eagle Mountain</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></span>
-                    <h4>Trusted Service</h4>
-                    <p>4.9 rating from 280+ Eagle Mountain families and businesses</p>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · EAGLE MOUNTAIN</p>
+                <h2>Need us out? Just tell us what's wrong.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No call center, no pressure, no upsell.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
                 </div>
             </div>
-        </section>
-        <section class="big-cta">
-            <h2>Ready for Expert HVAC Service in Eagle Mountain?</h2>
-            <p>Contact Air Express HVAC today for fast, professional service.</p>
-            <a href="contact.html" class="cta-btn" style="display: inline-block; background: white; color: var(--secondary); border-color: white; margin-top: 10px;">Request Free Estimate</a>
         </section>
     </main>
 

--- a/service-area-highland.html
+++ b/service-area-highland.html
@@ -102,57 +102,50 @@
     </header>
 
     <main id="main" tabindex="-1">
-<section class="hero">
-            <div class="hero-content">
-                <h1>HVAC Services in Highland, Utah</h1>
-                <p>Professional heating and cooling services for Highland homes and businesses.</p>
-                <div class="hero-ctas">
-                    <a href="contact.html" class="primary">Get Free Estimate</a>
-                    <a href="tel:+18017668585" class="secondary">Call: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/trust-porch-utah-1200.webp'); --hero-bg-desktop: url('/images/trust-porch-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FAMILY-OWNED · SINCE 1996 · HIGHLAND, UTAH</p>
+                <h1>Your neighbors in heating<br>&amp; cooling — Highland, UT.</h1>
+                <p class="service-hero-sub">Same family, same crew, same phone number since 1996. We've been keeping Highland homes comfortable for three generations — and we'd like to be your heating and cooling company too.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
-        <section class="section">
-            <h2 class="section-title">Highland HVAC Services</h2>
-            <div class="content">
-                <h2>Your Local HVAC Experts in Highland</h2>
-                <p>Air Express HVAC proudly serves the Highland community with expert heating and cooling services. Whether you need AC installation for summer comfort, furnace repair for winter warmth, or regular maintenance to keep your system running smoothly, our licensed and insured technicians are here to help.</p>
-                <h3 style="font-family: Georgia, serif; color: var(--primary); font-size: 24px; margin-top: 30px; margin-bottom: 15px;">Services Available in Highland:</h3>
-                <ul style="list-style-position: inside; line-height: 1.8;">
-                    <li><strong>AC Installation & Repair</strong> - Beat Highland's hot summers with reliable air conditioning</li>
-                    <li><strong>Furnace Services</strong> - Dependable heating for Highland's cold winters</li>
-                    <li><strong>Heat Pump Installation</strong> - Efficient year-round comfort systems</li>
-                    <li><strong>Maintenance Plans</strong> - Keep your system running smoothly all year</li>
-                    <li><strong>Emergency Service</strong> - 24/7 availability when you need us most</li>
-                    <li><strong>Air Quality Solutions</strong> - Healthier indoor air for your Highland home</li>
-                </ul>
-                <p style="margin-top: 20px;">With nearly 30 years of experience serving Utah County, Air Express HVAC understands Highland's unique climate challenges. We're committed to providing fast, honest service backed by expert technicians and fair pricing.</p>
-            </div>
-        </section>
-        <section class="why-us">
-            <h2 class="section-title">Why Choose Air Express for Highland?</h2>
-            <div class="why-us-grid">
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12c0 5.33 3.95 9.75 9 10.92V22h2v-2.08c5.05-1.17 9-5.59 9-10.92 0-5.52-4.48-10-10-10zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-13c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5z"/></svg></span>
-                    <h3>Local Experts</h3>
-                    <p>Serving Highland for nearly 30 years with local knowledge and expertise</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg></span>
-                    <h4>Fast Response</h4>
-                    <p>Quick service with 24/7 emergency availability for Highland</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></span>
-                    <h4>Trusted Service</h4>
-                    <p>4.9 rating from 280+ Highland families and businesses</p>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · HIGHLAND</p>
+                <h2>Need us out? Just tell us what's wrong.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No call center, no pressure, no upsell.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
                 </div>
             </div>
-        </section>
-        <section class="big-cta">
-            <h2>Ready for Expert HVAC Service in Highland?</h2>
-            <p>Contact Air Express HVAC today for fast, professional service.</p>
-            <a href="contact.html" class="cta-btn" style="display: inline-block; background: white; color: var(--secondary); border-color: white; margin-top: 10px;">Request Free Estimate</a>
         </section>
     </main>
 

--- a/service-area-lehi.html
+++ b/service-area-lehi.html
@@ -80,24 +80,51 @@
     </header>
 
     <main id="main" tabindex="-1">
-        <section class="service-hero">
-            <div class="hero-content">
-                <h1>Lehi, UT Air Conditioning &amp; Heating Services</h1>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/trust-porch-utah-1200.webp'); --hero-bg-desktop: url('/images/trust-porch-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FAMILY-OWNED · SINCE 1996 · LEHI, UTAH</p>
+                <h1>Your neighbors in heating<br>&amp; cooling — Lehi, UT.</h1>
+                <p class="service-hero-sub">Same family, same crew, same phone number since 1996. We've been keeping Lehi homes comfortable for three generations — and we'd like to be your heating and cooling company too.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
+                </div>
             </div>
         </section>
 
-        <section class="content-section">
-            <div class="container">
-                <h2>Your Trusted HVAC Partner in Lehi, Utah</h2>
-                <p><strong>Air Conditioning &amp; Heating Services In Lehi, UT</strong></p><p>Air Express Heating and Air Conditioning is proud to serve the Lehi community with professional HVAC services. From AC repair and furnace installation to indoor air quality solutions, our experienced team is here to keep your home comfortable year-round.</p>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · LEHI</p>
+                <h2>Need us out? Just tell us what's wrong.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No call center, no pressure, no upsell.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
+                </div>
             </div>
-        </section>
-
-        <section class="big-cta">
-            <h2>Ready to Get Started?</h2>
-            <p>Contact Us For HVAC Services In Lehi, UT</p>
-            <a href="contact.html" class="cta-btn">Contact Us Today</a>
-            <p style="margin-top:1rem;"><a href="tel:+18017668585" style="color:#fff;">(801) 766-8585</a></p>
         </section>
     </main>
 

--- a/service-area-orem.html
+++ b/service-area-orem.html
@@ -102,57 +102,50 @@
     </header>
 
     <main id="main" tabindex="-1">
-<section class="hero">
-            <div class="hero-content">
-                <h1>HVAC Services in Orem, Utah</h1>
-                <p>Professional heating and cooling services for Orem homes and businesses.</p>
-                <div class="hero-ctas">
-                    <a href="contact.html" class="primary">Get Free Estimate</a>
-                    <a href="tel:+18017668585" class="secondary">Call: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/trust-porch-utah-1200.webp'); --hero-bg-desktop: url('/images/trust-porch-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FAMILY-OWNED · SINCE 1996 · OREM, UTAH</p>
+                <h1>Your neighbors in heating<br>&amp; cooling — Orem, UT.</h1>
+                <p class="service-hero-sub">Same family, same crew, same phone number since 1996. We've been keeping Orem homes comfortable for three generations — and we'd like to be your heating and cooling company too.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
-        <section class="section">
-            <h2 class="section-title">Orem HVAC Services</h2>
-            <div class="content">
-                <h2>Your Local HVAC Experts in Orem</h2>
-                <p>Air Express HVAC proudly serves the Orem community with expert heating and cooling services. Whether you need AC installation for summer comfort, furnace repair for winter warmth, or regular maintenance to keep your system running smoothly, our licensed and insured technicians are here to help.</p>
-                <h3 style="font-family: Georgia, serif; color: var(--primary); font-size: 24px; margin-top: 30px; margin-bottom: 15px;">Services Available in Orem:</h3>
-                <ul style="list-style-position: inside; line-height: 1.8;">
-                    <li><strong>AC Installation & Repair</strong> - Beat Orem's hot summers with reliable air conditioning</li>
-                    <li><strong>Furnace Services</strong> - Dependable heating for Orem's cold winters</li>
-                    <li><strong>Heat Pump Installation</strong> - Efficient year-round comfort systems</li>
-                    <li><strong>Maintenance Plans</strong> - Keep your system running smoothly all year</li>
-                    <li><strong>Emergency Service</strong> - 24/7 availability when you need us most</li>
-                    <li><strong>Air Quality Solutions</strong> - Healthier indoor air for your Orem home</li>
-                </ul>
-                <p style="margin-top: 20px;">With nearly 30 years of experience serving Utah County, Air Express HVAC understands Orem's unique climate challenges. We're committed to providing fast, honest service backed by expert technicians and fair pricing.</p>
-            </div>
-        </section>
-        <section class="why-us">
-            <h2 class="section-title">Why Choose Air Express for Orem?</h2>
-            <div class="why-us-grid">
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12c0 5.33 3.95 9.75 9 10.92V22h2v-2.08c5.05-1.17 9-5.59 9-10.92 0-5.52-4.48-10-10-10zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-13c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5z"/></svg></span>
-                    <h3>Local Experts</h3>
-                    <p>Serving Orem for nearly 30 years with local knowledge and expertise</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg></span>
-                    <h4>Fast Response</h4>
-                    <p>Quick service with 24/7 emergency availability for Orem</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></span>
-                    <h4>Trusted Service</h4>
-                    <p>4.9 rating from 280+ Orem families and businesses</p>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · OREM</p>
+                <h2>Need us out? Just tell us what's wrong.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No call center, no pressure, no upsell.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
                 </div>
             </div>
-        </section>
-        <section class="big-cta">
-            <h2>Ready for Expert HVAC Service in Orem?</h2>
-            <p>Contact Air Express HVAC today for fast, professional service.</p>
-            <a href="contact.html" class="cta-btn" style="display: inline-block; background: white; color: var(--secondary); border-color: white; margin-top: 10px;">Request Free Estimate</a>
         </section>
     </main>
 

--- a/service-area-pleasant-grove.html
+++ b/service-area-pleasant-grove.html
@@ -102,57 +102,50 @@
     </header>
 
     <main id="main" tabindex="-1">
-<section class="hero">
-            <div class="hero-content">
-                <h1>HVAC Services in Pleasant Grove, Utah</h1>
-                <p>Professional heating and cooling services for Pleasant Grove homes and businesses.</p>
-                <div class="hero-ctas">
-                    <a href="contact.html" class="primary">Get Free Estimate</a>
-                    <a href="tel:+18017668585" class="secondary">Call: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/trust-porch-utah-1200.webp'); --hero-bg-desktop: url('/images/trust-porch-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FAMILY-OWNED · SINCE 1996 · PLEASANT GROVE, UTAH</p>
+                <h1>Your neighbors in heating<br>&amp; cooling — Pleasant Grove, UT.</h1>
+                <p class="service-hero-sub">Same family, same crew, same phone number since 1996. We've been keeping Pleasant Grove homes comfortable for three generations — and we'd like to be your heating and cooling company too.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
-        <section class="section">
-            <h2 class="section-title">Pleasant Grove HVAC Services</h2>
-            <div class="content">
-                <h2>Your Local HVAC Experts in Pleasant Grove</h2>
-                <p>Air Express HVAC proudly serves the Pleasant Grove community with expert heating and cooling services. Whether you need AC installation for summer comfort, furnace repair for winter warmth, or regular maintenance to keep your system running smoothly, our licensed and insured technicians are here to help.</p>
-                <h3 style="font-family: Georgia, serif; color: var(--primary); font-size: 24px; margin-top: 30px; margin-bottom: 15px;">Services Available in Pleasant Grove:</h3>
-                <ul style="list-style-position: inside; line-height: 1.8;">
-                    <li><strong>AC Installation & Repair</strong> - Beat Pleasant Grove's hot summers with reliable air conditioning</li>
-                    <li><strong>Furnace Services</strong> - Dependable heating for Pleasant Grove's cold winters</li>
-                    <li><strong>Heat Pump Installation</strong> - Efficient year-round comfort systems</li>
-                    <li><strong>Maintenance Plans</strong> - Keep your system running smoothly all year</li>
-                    <li><strong>Emergency Service</strong> - 24/7 availability when you need us most</li>
-                    <li><strong>Air Quality Solutions</strong> - Healthier indoor air for your Pleasant Grove home</li>
-                </ul>
-                <p style="margin-top: 20px;">With nearly 30 years of experience serving Utah County, Air Express HVAC understands Pleasant Grove's unique climate challenges. We're committed to providing fast, honest service backed by expert technicians and fair pricing.</p>
-            </div>
-        </section>
-        <section class="why-us">
-            <h2 class="section-title">Why Choose Air Express for Pleasant Grove?</h2>
-            <div class="why-us-grid">
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12c0 5.33 3.95 9.75 9 10.92V22h2v-2.08c5.05-1.17 9-5.59 9-10.92 0-5.52-4.48-10-10-10zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-13c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5z"/></svg></span>
-                    <h3>Local Experts</h3>
-                    <p>Serving Pleasant Grove for nearly 30 years with local knowledge and expertise</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg></span>
-                    <h4>Fast Response</h4>
-                    <p>Quick service with 24/7 emergency availability for Pleasant Grove</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></span>
-                    <h4>Trusted Service</h4>
-                    <p>4.9 rating from 280+ Pleasant Grove families and businesses</p>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · PLEASANT GROVE</p>
+                <h2>Need us out? Just tell us what's wrong.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No call center, no pressure, no upsell.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
                 </div>
             </div>
-        </section>
-        <section class="big-cta">
-            <h2>Ready for Expert HVAC Service in Pleasant Grove?</h2>
-            <p>Contact Air Express HVAC today for fast, professional service.</p>
-            <a href="contact.html" class="cta-btn" style="display: inline-block; background: white; color: var(--secondary); border-color: white; margin-top: 10px;">Request Free Estimate</a>
         </section>
     </main>
 

--- a/service-area-provo.html
+++ b/service-area-provo.html
@@ -102,57 +102,50 @@
     </header>
 
     <main id="main" tabindex="-1">
-<section class="hero">
-            <div class="hero-content">
-                <h1>HVAC Services in Provo, Utah</h1>
-                <p>Professional heating and cooling services for Provo homes and businesses.</p>
-                <div class="hero-ctas">
-                    <a href="contact.html" class="primary">Get Free Estimate</a>
-                    <a href="tel:+18017668585" class="secondary">Call: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/trust-porch-utah-1200.webp'); --hero-bg-desktop: url('/images/trust-porch-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FAMILY-OWNED · SINCE 1996 · PROVO, UTAH</p>
+                <h1>Your neighbors in heating<br>&amp; cooling — Provo, UT.</h1>
+                <p class="service-hero-sub">Same family, same crew, same phone number since 1996. We've been keeping Provo homes comfortable for three generations — and we'd like to be your heating and cooling company too.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
-        <section class="section">
-            <h2 class="section-title">Provo HVAC Services</h2>
-            <div class="content">
-                <h2>Your Local HVAC Experts in Provo</h2>
-                <p>Air Express HVAC proudly serves the Provo community with expert heating and cooling services. Whether you need AC installation for summer comfort, furnace repair for winter warmth, or regular maintenance to keep your system running smoothly, our licensed and insured technicians are here to help.</p>
-                <h3 style="font-family: Georgia, serif; color: var(--primary); font-size: 24px; margin-top: 30px; margin-bottom: 15px;">Services Available in Provo:</h3>
-                <ul style="list-style-position: inside; line-height: 1.8;">
-                    <li><strong>AC Installation & Repair</strong> - Beat Provo's hot summers with reliable air conditioning</li>
-                    <li><strong>Furnace Services</strong> - Dependable heating for Provo's cold winters</li>
-                    <li><strong>Heat Pump Installation</strong> - Efficient year-round comfort systems</li>
-                    <li><strong>Maintenance Plans</strong> - Keep your system running smoothly all year</li>
-                    <li><strong>Emergency Service</strong> - 24/7 availability when you need us most</li>
-                    <li><strong>Air Quality Solutions</strong> - Healthier indoor air for your Provo home</li>
-                </ul>
-                <p style="margin-top: 20px;">With nearly 30 years of experience serving Utah County, Air Express HVAC understands Provo's unique climate challenges. We're committed to providing fast, honest service backed by expert technicians and fair pricing.</p>
-            </div>
-        </section>
-        <section class="why-us">
-            <h2 class="section-title">Why Choose Air Express for Provo?</h2>
-            <div class="why-us-grid">
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12c0 5.33 3.95 9.75 9 10.92V22h2v-2.08c5.05-1.17 9-5.59 9-10.92 0-5.52-4.48-10-10-10zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-13c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5z"/></svg></span>
-                    <h3>Local Experts</h3>
-                    <p>Serving Provo for nearly 30 years with local knowledge and expertise</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg></span>
-                    <h4>Fast Response</h4>
-                    <p>Quick service with 24/7 emergency availability for Provo</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></span>
-                    <h4>Trusted Service</h4>
-                    <p>4.9 rating from 280+ Provo families and businesses</p>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · PROVO</p>
+                <h2>Need us out? Just tell us what's wrong.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No call center, no pressure, no upsell.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
                 </div>
             </div>
-        </section>
-        <section class="big-cta">
-            <h2>Ready for Expert HVAC Service in Provo?</h2>
-            <p>Contact Air Express HVAC today for fast, professional service.</p>
-            <a href="contact.html" class="cta-btn" style="display: inline-block; background: white; color: var(--secondary); border-color: white; margin-top: 10px;">Request Free Estimate</a>
         </section>
     </main>
 

--- a/service-area-sandy.html
+++ b/service-area-sandy.html
@@ -102,57 +102,50 @@
     </header>
 
     <main id="main" tabindex="-1">
-<section class="hero">
-            <div class="hero-content">
-                <h1>HVAC Services in Sandy, Utah</h1>
-                <p>Professional heating and cooling services for Sandy homes and businesses.</p>
-                <div class="hero-ctas">
-                    <a href="contact.html" class="primary">Get Free Estimate</a>
-                    <a href="tel:+18017668585" class="secondary">Call: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/trust-porch-utah-1200.webp'); --hero-bg-desktop: url('/images/trust-porch-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FAMILY-OWNED · SINCE 1996 · SANDY, UTAH</p>
+                <h1>Your neighbors in heating<br>&amp; cooling — Sandy, UT.</h1>
+                <p class="service-hero-sub">Same family, same crew, same phone number since 1996. We've been keeping Sandy homes comfortable for three generations — and we'd like to be your heating and cooling company too.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
-        <section class="section">
-            <h2 class="section-title">Sandy HVAC Services</h2>
-            <div class="content">
-                <h2>Your Local HVAC Experts in Sandy</h2>
-                <p>Air Express HVAC proudly serves the Sandy community with expert heating and cooling services. Whether you need AC installation for summer comfort, furnace repair for winter warmth, or regular maintenance to keep your system running smoothly, our licensed and insured technicians are here to help.</p>
-                <h3 style="font-family: Georgia, serif; color: var(--primary); font-size: 24px; margin-top: 30px; margin-bottom: 15px;">Services Available in Sandy:</h3>
-                <ul style="list-style-position: inside; line-height: 1.8;">
-                    <li><strong>AC Installation & Repair</strong> - Beat Sandy's hot summers with reliable air conditioning</li>
-                    <li><strong>Furnace Services</strong> - Dependable heating for Sandy's cold winters</li>
-                    <li><strong>Heat Pump Installation</strong> - Efficient year-round comfort systems</li>
-                    <li><strong>Maintenance Plans</strong> - Keep your system running smoothly all year</li>
-                    <li><strong>Emergency Service</strong> - 24/7 availability when you need us most</li>
-                    <li><strong>Air Quality Solutions</strong> - Healthier indoor air for your Sandy home</li>
-                </ul>
-                <p style="margin-top: 20px;">With nearly 30 years of experience serving Utah County, Air Express HVAC understands Sandy's unique climate challenges. We're committed to providing fast, honest service backed by expert technicians and fair pricing.</p>
-            </div>
-        </section>
-        <section class="why-us">
-            <h2 class="section-title">Why Choose Air Express for Sandy?</h2>
-            <div class="why-us-grid">
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12c0 5.33 3.95 9.75 9 10.92V22h2v-2.08c5.05-1.17 9-5.59 9-10.92 0-5.52-4.48-10-10-10zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-13c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5z"/></svg></span>
-                    <h3>Local Experts</h3>
-                    <p>Serving Sandy for nearly 30 years with local knowledge and expertise</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg></span>
-                    <h4>Fast Response</h4>
-                    <p>Quick service with 24/7 emergency availability for Sandy</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></span>
-                    <h4>Trusted Service</h4>
-                    <p>4.9 rating from 280+ Sandy families and businesses</p>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · SANDY</p>
+                <h2>Need us out? Just tell us what's wrong.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No call center, no pressure, no upsell.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
                 </div>
             </div>
-        </section>
-        <section class="big-cta">
-            <h2>Ready for Expert HVAC Service in Sandy?</h2>
-            <p>Contact Air Express HVAC today for fast, professional service.</p>
-            <a href="contact.html" class="cta-btn" style="display: inline-block; background: white; color: var(--secondary); border-color: white; margin-top: 10px;">Request Free Estimate</a>
         </section>
     </main>
 

--- a/service-area-saratoga-springs.html
+++ b/service-area-saratoga-springs.html
@@ -102,57 +102,50 @@
     </header>
 
     <main id="main" tabindex="-1">
-<section class="hero">
-            <div class="hero-content">
-                <h1>HVAC Services in Saratoga Springs, Utah</h1>
-                <p>Professional heating and cooling services for Saratoga Springs homes and businesses.</p>
-                <div class="hero-ctas">
-                    <a href="contact.html" class="primary">Get Free Estimate</a>
-                    <a href="tel:+18017668585" class="secondary">Call: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/trust-porch-utah-1200.webp'); --hero-bg-desktop: url('/images/trust-porch-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FAMILY-OWNED · SINCE 1996 · SARATOGA SPRINGS, UTAH</p>
+                <h1>Your neighbors in heating<br>&amp; cooling — Saratoga Springs, UT.</h1>
+                <p class="service-hero-sub">Same family, same crew, same phone number since 1996. We've been keeping Saratoga Springs homes comfortable for three generations — and we'd like to be your heating and cooling company too.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
-        <section class="section">
-            <h2 class="section-title">Saratoga Springs HVAC Services</h2>
-            <div class="content">
-                <h2>Your Local HVAC Experts in Saratoga Springs</h2>
-                <p>Air Express HVAC proudly serves the Saratoga Springs community with expert heating and cooling services. Whether you need AC installation for summer comfort, furnace repair for winter warmth, or regular maintenance to keep your system running smoothly, our licensed and insured technicians are here to help.</p>
-                <h3 style="font-family: Georgia, serif; color: var(--primary); font-size: 24px; margin-top: 30px; margin-bottom: 15px;">Services Available in Saratoga Springs:</h3>
-                <ul style="list-style-position: inside; line-height: 1.8;">
-                    <li><strong>AC Installation & Repair</strong> - Beat Saratoga Springs's hot summers with reliable air conditioning</li>
-                    <li><strong>Furnace Services</strong> - Dependable heating for Saratoga Springs's cold winters</li>
-                    <li><strong>Heat Pump Installation</strong> - Efficient year-round comfort systems</li>
-                    <li><strong>Maintenance Plans</strong> - Keep your system running smoothly all year</li>
-                    <li><strong>Emergency Service</strong> - 24/7 availability when you need us most</li>
-                    <li><strong>Air Quality Solutions</strong> - Healthier indoor air for your Saratoga Springs home</li>
-                </ul>
-                <p style="margin-top: 20px;">With nearly 30 years of experience serving Utah County, Air Express HVAC understands Saratoga Springs's unique climate challenges. We're committed to providing fast, honest service backed by expert technicians and fair pricing.</p>
-            </div>
-        </section>
-        <section class="why-us">
-            <h2 class="section-title">Why Choose Air Express for Saratoga Springs?</h2>
-            <div class="why-us-grid">
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12c0 5.33 3.95 9.75 9 10.92V22h2v-2.08c5.05-1.17 9-5.59 9-10.92 0-5.52-4.48-10-10-10zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-13c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5z"/></svg></span>
-                    <h3>Local Experts</h3>
-                    <p>Serving Saratoga Springs for nearly 30 years with local knowledge and expertise</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg></span>
-                    <h4>Fast Response</h4>
-                    <p>Quick service with 24/7 emergency availability for Saratoga Springs</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></span>
-                    <h4>Trusted Service</h4>
-                    <p>4.9 rating from 280+ Saratoga Springs families and businesses</p>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · SARATOGA SPRINGS</p>
+                <h2>Need us out? Just tell us what's wrong.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No call center, no pressure, no upsell.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
                 </div>
             </div>
-        </section>
-        <section class="big-cta">
-            <h2>Ready for Expert HVAC Service in Saratoga Springs?</h2>
-            <p>Contact Air Express HVAC today for fast, professional service.</p>
-            <a href="contact.html" class="cta-btn" style="display: inline-block; background: white; color: var(--secondary); border-color: white; margin-top: 10px;">Request Free Estimate</a>
         </section>
     </main>
 

--- a/service-area-south-jordan.html
+++ b/service-area-south-jordan.html
@@ -102,57 +102,50 @@
     </header>
 
     <main id="main" tabindex="-1">
-<section class="hero">
-            <div class="hero-content">
-                <h1>HVAC Services in South Jordan, Utah</h1>
-                <p>Professional heating and cooling services for South Jordan homes and businesses.</p>
-                <div class="hero-ctas">
-                    <a href="contact.html" class="primary">Get Free Estimate</a>
-                    <a href="tel:+18017668585" class="secondary">Call: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/trust-porch-utah-1200.webp'); --hero-bg-desktop: url('/images/trust-porch-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FAMILY-OWNED · SINCE 1996 · SOUTH JORDAN, UTAH</p>
+                <h1>Your neighbors in heating<br>&amp; cooling — South Jordan, UT.</h1>
+                <p class="service-hero-sub">Same family, same crew, same phone number since 1996. We've been keeping South Jordan homes comfortable for three generations — and we'd like to be your heating and cooling company too.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
-        <section class="section">
-            <h2 class="section-title">South Jordan HVAC Services</h2>
-            <div class="content">
-                <h2>Your Local HVAC Experts in South Jordan</h2>
-                <p>Air Express HVAC proudly serves the South Jordan community with expert heating and cooling services. Whether you need AC installation for summer comfort, furnace repair for winter warmth, or regular maintenance to keep your system running smoothly, our licensed and insured technicians are here to help.</p>
-                <h3 style="font-family: Georgia, serif; color: var(--primary); font-size: 24px; margin-top: 30px; margin-bottom: 15px;">Services Available in South Jordan:</h3>
-                <ul style="list-style-position: inside; line-height: 1.8;">
-                    <li><strong>AC Installation & Repair</strong> - Beat South Jordan's hot summers with reliable air conditioning</li>
-                    <li><strong>Furnace Services</strong> - Dependable heating for South Jordan's cold winters</li>
-                    <li><strong>Heat Pump Installation</strong> - Efficient year-round comfort systems</li>
-                    <li><strong>Maintenance Plans</strong> - Keep your system running smoothly all year</li>
-                    <li><strong>Emergency Service</strong> - 24/7 availability when you need us most</li>
-                    <li><strong>Air Quality Solutions</strong> - Healthier indoor air for your South Jordan home</li>
-                </ul>
-                <p style="margin-top: 20px;">With nearly 30 years of experience serving Utah County, Air Express HVAC understands South Jordan's unique climate challenges. We're committed to providing fast, honest service backed by expert technicians and fair pricing.</p>
-            </div>
-        </section>
-        <section class="why-us">
-            <h2 class="section-title">Why Choose Air Express for South Jordan?</h2>
-            <div class="why-us-grid">
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12c0 5.33 3.95 9.75 9 10.92V22h2v-2.08c5.05-1.17 9-5.59 9-10.92 0-5.52-4.48-10-10-10zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-13c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5z"/></svg></span>
-                    <h3>Local Experts</h3>
-                    <p>Serving South Jordan for nearly 30 years with local knowledge and expertise</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg></span>
-                    <h4>Fast Response</h4>
-                    <p>Quick service with 24/7 emergency availability for South Jordan</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></span>
-                    <h4>Trusted Service</h4>
-                    <p>4.9 rating from 280+ South Jordan families and businesses</p>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · SOUTH JORDAN</p>
+                <h2>Need us out? Just tell us what's wrong.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No call center, no pressure, no upsell.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
                 </div>
             </div>
-        </section>
-        <section class="big-cta">
-            <h2>Ready for Expert HVAC Service in South Jordan?</h2>
-            <p>Contact Air Express HVAC today for fast, professional service.</p>
-            <a href="contact.html" class="cta-btn" style="display: inline-block; background: white; color: var(--secondary); border-color: white; margin-top: 10px;">Request Free Estimate</a>
         </section>
     </main>
 

--- a/service-area-west-jordan.html
+++ b/service-area-west-jordan.html
@@ -102,57 +102,50 @@
     </header>
 
     <main id="main" tabindex="-1">
-<section class="hero">
-            <div class="hero-content">
-                <h1>HVAC Services in West Jordan, Utah</h1>
-                <p>Professional heating and cooling services for West Jordan homes and businesses.</p>
-                <div class="hero-ctas">
-                    <a href="contact.html" class="primary">Get Free Estimate</a>
-                    <a href="tel:+18017668585" class="secondary">Call: (801) 766-8585</a>
+        <section class="service-hero" style="--hero-bg-mobile: url('/images/trust-porch-utah-1200.webp'); --hero-bg-desktop: url('/images/trust-porch-utah-1800.webp');">
+            <div class="service-hero-inner">
+                <p class="service-hero-eyebrow">FAMILY-OWNED · SINCE 1996 · WEST JORDAN, UTAH</p>
+                <h1>Your neighbors in heating<br>&amp; cooling — West Jordan, UT.</h1>
+                <p class="service-hero-sub">Same family, same crew, same phone number since 1996. We've been keeping West Jordan homes comfortable for three generations — and we'd like to be your heating and cooling company too.</p>
+                <a href="contact.html" class="service-hero-cta">
+                    Get Your Free Estimate
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                </a>
+            </div>
+            <div class="service-hero-stats" aria-label="Trust signals">
+                <div class="service-stat">
+                    <span class="service-stat-num">4.9★</span>
+                    <span class="service-stat-label">280+ reviews</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">&lt;1hr</span>
+                    <span class="service-stat-label">callback</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">30 yr</span>
+                    <span class="service-stat-label">family-owned</span>
+                </div>
+                <div class="service-stat">
+                    <span class="service-stat-num">24/7</span>
+                    <span class="service-stat-label">emergency</span>
                 </div>
             </div>
         </section>
-        <section class="section">
-            <h2 class="section-title">West Jordan HVAC Services</h2>
-            <div class="content">
-                <h2>Your Local HVAC Experts in West Jordan</h2>
-                <p>Air Express HVAC proudly serves the West Jordan community with expert heating and cooling services. Whether you need AC installation for summer comfort, furnace repair for winter warmth, or regular maintenance to keep your system running smoothly, our licensed and insured technicians are here to help.</p>
-                <h3 style="font-family: Georgia, serif; color: var(--primary); font-size: 24px; margin-top: 30px; margin-bottom: 15px;">Services Available in West Jordan:</h3>
-                <ul style="list-style-position: inside; line-height: 1.8;">
-                    <li><strong>AC Installation & Repair</strong> - Beat West Jordan's hot summers with reliable air conditioning</li>
-                    <li><strong>Furnace Services</strong> - Dependable heating for West Jordan's cold winters</li>
-                    <li><strong>Heat Pump Installation</strong> - Efficient year-round comfort systems</li>
-                    <li><strong>Maintenance Plans</strong> - Keep your system running smoothly all year</li>
-                    <li><strong>Emergency Service</strong> - 24/7 availability when you need us most</li>
-                    <li><strong>Air Quality Solutions</strong> - Healthier indoor air for your West Jordan home</li>
-                </ul>
-                <p style="margin-top: 20px;">With nearly 30 years of experience serving Utah County, Air Express HVAC understands West Jordan's unique climate challenges. We're committed to providing fast, honest service backed by expert technicians and fair pricing.</p>
-            </div>
-        </section>
-        <section class="why-us">
-            <h2 class="section-title">Why Choose Air Express for West Jordan?</h2>
-            <div class="why-us-grid">
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12c0 5.33 3.95 9.75 9 10.92V22h2v-2.08c5.05-1.17 9-5.59 9-10.92 0-5.52-4.48-10-10-10zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-13c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5z"/></svg></span>
-                    <h3>Local Experts</h3>
-                    <p>Serving West Jordan for nearly 30 years with local knowledge and expertise</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg></span>
-                    <h4>Fast Response</h4>
-                    <p>Quick service with 24/7 emergency availability for West Jordan</p>
-                </div>
-                <div class="why-item">
-                    <span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg></span>
-                    <h4>Trusted Service</h4>
-                    <p>4.9 rating from 280+ West Jordan families and businesses</p>
+        <section class="trust-card">
+            <div class="trust-card-inner">
+                <p class="trust-card-eyebrow">NEXT STEP · WEST JORDAN</p>
+                <h2>Need us out? Just tell us what's wrong.</h2>
+                <p>We'll come take a look, tell you honestly what we'd do about it, and give you a written estimate before any work starts. No call center, no pressure, no upsell.</p>
+                <div class="trust-card-actions">
+                    <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
+                        Get Your Free Estimate
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+                    </a>
+                    <a href="tel:+18017668585" class="trust-card-btn trust-card-btn--secondary">
+                        (801) 766-8585
+                    </a>
                 </div>
             </div>
-        </section>
-        <section class="big-cta">
-            <h2>Ready for Expert HVAC Service in West Jordan?</h2>
-            <p>Contact Air Express HVAC today for fast, professional service.</p>
-            <a href="contact.html" class="cta-btn" style="display: inline-block; background: white; color: var(--secondary); border-color: white; margin-top: 10px;">Request Free Estimate</a>
         </section>
     </main>
 


### PR DESCRIPTION
## Summary

- Converts 14 `service-area-*.html` and 22 `*-{city}-ut.html` pages to the editorial service-hero pattern from Phase 5A/5B
- Replaces 20 off-palette `#8B4513` saddle-brown inline CTA sections with the new `.trust-card` block
- Removes duplicate `<footer role="contentinfo">` blocks + inline nav-toggle scripts from 22 geo pages (leftover broken nesting from the old template)
- Rewrites corporate third-person voice ("Air Express HVAC proudly serves...") to the collective "we" voice matching the homepage / about / services refresh
- Fixes "nearly 30 years" grammar → "thirty years"
- Each page now has a voice-aware hero headline (e.g. _"When your AC quits in Orem, we're on our way."_ / _"Furnace down in Sandy? We're driving over."_ / _"Your neighbors in heating & cooling — Alpine, UT."_)

## Test plan

- [x] `npx playwright test --project=chromium-desktop tests/e2e/smoke.spec.js` — 14 passed, 1 skipped, 0 failed
- [x] `grep #8B4513 *-ut.html` returns empty (no saddle-brown survives)
- [x] `grep -c "<footer" *-ut.html` returns 1 for every geo page (no dup footers)
- [x] Spot-checked `service-area-alpine.html`, `ac-installation-saratoga-springs-ut.html`, `furnace-repair-eagle-mountain-ut.html` visually in the diff

## Status: Wave 5

- 5A: pillar pages (`heating-services`, `ac-services`) → ✅ shipped (PR #6)
- 5B: 27 service detail pages → ✅ shipped (PR #7)
- **5C: 14 service-area + 22 geo pages → ✅ this PR**
- 5D: division pages (`residential`, `commercial`, `multifamily`) + `reviews.html` + `emergency.html` → 📋 next
- 5E: `faq.html` + odds-and-ends → 📋 queued

🤖 Generated with [Claude Code](https://claude.com/claude-code)