### PR TITLE
Fix site-wide trust-card button order + heat-pump layout bugs

### DIFF
--- a/ac-inspection.html
+++ b/ac-inspection.html
@@ -224,11 +224,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/ac-installation.html
+++ b/ac-installation.html
@@ -214,11 +214,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/ac-maintenance.html
+++ b/ac-maintenance.html
@@ -214,11 +214,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/ac-repair.html
+++ b/ac-repair.html
@@ -210,11 +210,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/ac-replacement.html
+++ b/ac-replacement.html
@@ -214,11 +214,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/ac-services.html
+++ b/ac-services.html
@@ -196,11 +196,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps your family stay cool this summer, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/ac-tune-up.html
+++ b/ac-tune-up.html
@@ -214,11 +214,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/air-duct-cleaning.html
+++ b/air-duct-cleaning.html
@@ -204,11 +204,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/air-filters.html
+++ b/air-filters.html
@@ -209,11 +209,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/air-purifiers.html
+++ b/air-purifiers.html
@@ -204,11 +204,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/ductless.html
+++ b/ductless.html
@@ -198,11 +198,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/ductwork.html
+++ b/ductwork.html
@@ -210,11 +210,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/fireplace.html
+++ b/fireplace.html
@@ -198,11 +198,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/furnace-installation.html
+++ b/furnace-installation.html
@@ -217,11 +217,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/furnace-maintenance.html
+++ b/furnace-maintenance.html
@@ -217,11 +217,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/furnace-repair.html
+++ b/furnace-repair.html
@@ -217,11 +217,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/furnace.html
+++ b/furnace.html
@@ -217,11 +217,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/gas-lines.html
+++ b/gas-lines.html
@@ -209,11 +209,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/heat-pump.html
+++ b/heat-pump.html
@@ -186,7 +186,7 @@
         </section>
 
         <!-- ============ THE UTAH HEAT PUMP MATH ============ -->
-        <section class="section heat-pump-math">
+        <section class="heat-pump-math">
             <div class="heat-pump-math-inner">
                 <div class="heat-pump-math-copy">
                     <p class="heat-pump-math-eyebrow">THE UTAH MATH</p>
@@ -216,7 +216,7 @@
         </section>
 
         <!-- ============ BRANDS STRIP ============ -->
-        <section class="section brand-strip">
+        <section class="brand-strip">
             <p class="brand-strip-label">Factory-trained on</p>
             <div class="brand-strip-list">
                 <span class="brand-strip-item">Mitsubishi Electric</span>
@@ -234,11 +234,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/heating-installation.html
+++ b/heating-installation.html
@@ -217,11 +217,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/heating-maintenance.html
+++ b/heating-maintenance.html
@@ -198,11 +198,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/heating-repair.html
+++ b/heating-repair.html
@@ -217,11 +217,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/heating-replacement.html
+++ b/heating-replacement.html
@@ -198,11 +198,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/heating-services.html
+++ b/heating-services.html
@@ -213,11 +213,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps your family stay warm this winter, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/heating-tune-up.html
+++ b/heating-tune-up.html
@@ -198,11 +198,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/indoor-air-quality.html
+++ b/indoor-air-quality.html
@@ -204,11 +204,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/styles.css
+++ b/styles.css
@@ -5060,10 +5060,13 @@ footer {
    34. Heat Pump Math Block + Brand Strip
    ========================================================================== */
 
+/* Full-bleed light section. Padding lives here (not on `.section`) so the
+   background color extends to the viewport edges on wide screens. */
 .heat-pump-math {
     background: var(--light);
     border-top: 1px solid var(--border);
     border-bottom: 1px solid var(--border);
+    padding: 72px 24px;
 }
 
 .heat-pump-math-inner {
@@ -5147,6 +5150,9 @@ footer {
 }
 
 @media (max-width: 900px) {
+    .heat-pump-math {
+        padding: 56px 20px;
+    }
     .heat-pump-math-inner {
         grid-template-columns: 1fr;
         gap: 40px;
@@ -5159,8 +5165,9 @@ footer {
 /* --- Brand strip --- */
 .brand-strip {
     text-align: center;
-    padding-top: 48px;
-    padding-bottom: 48px;
+    padding: 56px 24px;
+    max-width: 1180px;
+    margin: 0 auto;
 }
 
 .brand-strip-label {

--- a/thermostats.html
+++ b/thermostats.html
@@ -207,11 +207,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/ventilation.html
+++ b/ventilation.html
@@ -208,11 +208,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>

--- a/water-heater.html
+++ b/water-heater.html
@@ -204,11 +204,11 @@
                 <h2>No surprises. No hidden fees. Just an honest number.</h2>
                 <p>We give you a written estimate before any work starts. We don't pad bills, we don't pressure you to upgrade, and we don't charge you for repairs we didn't do. If financing helps, we offer 0% APR options through trusted lenders.</p>
                 <div class="trust-card-actions">
-                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                     <a href="contact.html" class="trust-card-btn trust-card-btn--primary">
                         Get Your Free Estimate
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
                     </a>
+                    <a href="financing.html" class="trust-card-btn trust-card-btn--secondary">Financing Options</a>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary

Review of `/heat-pump.html` surfaced formatting inconsistencies that turned out to be prevalent across the site.

### 1. Trust-card button order — 29 pages

Half the site had the closing trust-card CTAs reversed: `[Secondary] [Primary]` instead of `[Primary] [Secondary]`. The reversed pattern lived on **all Phase 5A pillars + all 27 Phase 5B service detail pages + heat-pump.html**. The 51 pages from Phase 5C/5D/5E already had the correct primary-first order.

In LTR reading order the main CTA belongs on the left — a user scanning the card should hit _"Get Your Free Estimate"_ before the de-emphasized fallback. Swapped all 29.

### 2. `.heat-pump-math` background not full-bleed

The previous PR added `<section class="section heat-pump-math">`, which inherited `.section { max-width: 1200px }`. The light-cream background was clipped to 1200px instead of extending to the viewport edges on wide screens, leaving awkward white bars on either side.

**Fix:** dropped the `.section` class, moved padding onto `.heat-pump-math` directly (72px 24px desktop / 56px 20px mobile), and let the background go full-bleed while keeping inner content capped at 1180px.

### 3. `.brand-strip` double padding

Same root cause — `<section class="section brand-strip">` applied `.section`'s 64/24 padding AND brand-strip's own 48/48 padding, creating rhythm inconsistency with neighboring sections. Dropped `.section`, explicit 56/24 padding.

## Test plan

- [x] `npx playwright test --project=chromium-desktop tests/e2e/smoke.spec.js` — 14 passed, 1 skipped, 0 failed
- [x] Verified button order on heat-pump, ac-services, heating-services, ac-repair, ductless — all now `primary, secondary`
- [x] Sweep script: `/tmp/fix_trust_card_button_order.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)