### PR TITLE
Audit sweep: wire up srcset + restore missing footer column on 20 geo pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -156,7 +156,7 @@
         <!-- ============ FULL-BLEED TEAM IMAGE BAND ============ -->
         <section class="about-team-band" aria-label="The Air Express team">
             <div class="about-team-band-inner">
-                <img src="images/team-utah.webp" width="1600" height="1200" alt="Three generations of the Air Express HVAC team standing in front of their Air Express van in Lehi Utah" loading="lazy">
+                <img src="images/team-utah-1200.webp" srcset="images/team-utah-1200.webp 1200w, images/team-utah-1800.webp 1800w" sizes="(max-width: 900px) 100vw, 50vw" width="1600" height="1200" alt="Three generations of the Air Express HVAC team standing in front of their Air Express van in Lehi Utah" loading="lazy">
                 <div class="about-team-band-caption">
                     <p class="about-team-caption-eyebrow">THE TEAM YOU'LL ACTUALLY MEET</p>
                     <p class="about-team-caption-body">The same faces answer the phone, show up at your door, and remember the quirks of your furnace next winter.</p>

--- a/ac-installation-eagle-mountain-ut.html
+++ b/ac-installation-eagle-mountain-ut.html
@@ -289,12 +289,19 @@
     <footer>
         <div class="footer-content">
             <div class="footer-section">
-                <h3>Services</h3>
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
                 <a href="ac-services.html">Air Conditioning</a>
-                <a href="heating-services.html">Furnace & Heating</a>
-                <a href="heat-pump.html">Heat Pumps</a>
-                <a href="ventilation.html">Ventilation & ERV</a>
-                <a href="air-filters.html">Air Filters</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
                 <a href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">
@@ -310,9 +317,6 @@
                 <a href="about.html">About Air Express</a>
                 <a href="careers.html">Careers</a>
                 <a href="resources.html">Resources & Tips</a>
-                <a href="faq.html">FAQ</a>
-                <a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a href="/blog/hvac-cost-guide.html">Cost Guide</a>
                 <a href="specials.html">Seasonal Specials</a>
                 <a href="financing.html">Financing</a>
             </div>
@@ -328,7 +332,7 @@
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
     </footer>
 <button class="back-to-top" aria-label="Back to top" title="Back to top">

--- a/ac-installation-lehi-ut.html
+++ b/ac-installation-lehi-ut.html
@@ -316,12 +316,19 @@
     <footer>
         <div class="footer-content">
             <div class="footer-section">
-                <h3>Services</h3>
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
                 <a href="ac-services.html">Air Conditioning</a>
-                <a href="heating-services.html">Furnace & Heating</a>
-                <a href="heat-pump.html">Heat Pumps</a>
-                <a href="ventilation.html">Ventilation & ERV</a>
-                <a href="air-filters.html">Air Filters</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
                 <a href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">
@@ -337,9 +344,6 @@
                 <a href="about.html">About Air Express</a>
                 <a href="careers.html">Careers</a>
                 <a href="resources.html">Resources & Tips</a>
-                <a href="faq.html">FAQ</a>
-                <a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a href="/blog/hvac-cost-guide.html">Cost Guide</a>
                 <a href="specials.html">Seasonal Specials</a>
                 <a href="financing.html">Financing</a>
             </div>
@@ -355,9 +359,9 @@
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-<button class="back-to-top" aria-label="Back to top" title="Back to top">
+    </footer><button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>
 <script src="nav.js" defer></script>

--- a/ac-installation-orem-ut.html
+++ b/ac-installation-orem-ut.html
@@ -316,12 +316,19 @@
     <footer>
         <div class="footer-content">
             <div class="footer-section">
-                <h3>Services</h3>
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
                 <a href="ac-services.html">Air Conditioning</a>
-                <a href="heating-services.html">Furnace & Heating</a>
-                <a href="heat-pump.html">Heat Pumps</a>
-                <a href="ventilation.html">Ventilation & ERV</a>
-                <a href="air-filters.html">Air Filters</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
                 <a href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">
@@ -337,9 +344,6 @@
                 <a href="about.html">About Air Express</a>
                 <a href="careers.html">Careers</a>
                 <a href="resources.html">Resources & Tips</a>
-                <a href="faq.html">FAQ</a>
-                <a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a href="/blog/hvac-cost-guide.html">Cost Guide</a>
                 <a href="specials.html">Seasonal Specials</a>
                 <a href="financing.html">Financing</a>
             </div>
@@ -355,9 +359,9 @@
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-<button class="back-to-top" aria-label="Back to top" title="Back to top">
+    </footer><button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>
 <script src="nav.js" defer></script>

--- a/ac-installation-sandy-ut.html
+++ b/ac-installation-sandy-ut.html
@@ -316,12 +316,19 @@
     <footer>
         <div class="footer-content">
             <div class="footer-section">
-                <h3>Services</h3>
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
                 <a href="ac-services.html">Air Conditioning</a>
-                <a href="heating-services.html">Furnace & Heating</a>
-                <a href="heat-pump.html">Heat Pumps</a>
-                <a href="ventilation.html">Ventilation & ERV</a>
-                <a href="air-filters.html">Air Filters</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
                 <a href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">
@@ -337,9 +344,6 @@
                 <a href="about.html">About Air Express</a>
                 <a href="careers.html">Careers</a>
                 <a href="resources.html">Resources & Tips</a>
-                <a href="faq.html">FAQ</a>
-                <a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a href="/blog/hvac-cost-guide.html">Cost Guide</a>
                 <a href="specials.html">Seasonal Specials</a>
                 <a href="financing.html">Financing</a>
             </div>
@@ -355,9 +359,9 @@
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-<button class="back-to-top" aria-label="Back to top" title="Back to top">
+    </footer><button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>
 <script src="nav.js" defer></script>

--- a/ac-installation-saratoga-springs-ut.html
+++ b/ac-installation-saratoga-springs-ut.html
@@ -216,15 +216,52 @@
 
     <footer>
         <div class="footer-content">
-            <div class="footer-section"><h3>Services</h3><a href="ac-services.html">Air Conditioning</a><a href="heat-pump.html">Furnace & Heating</a><a href="heat-pump.html">Heat Pumps</a><a href="ventilation.html">Ventilation</a><a href="air-filters.html">Air Filters</a><a href="thermostats.html">Thermostats</a></div>
-            <div class="footer-section"><h4>Community</h4><a href="residential.html">Residential</a><a href="commercial.html">Commercial</a><a href="multifamily.html">Multifamily</a><a href="service-areas.html">Service Areas</a><a href="reviews.html">Reviews</a></div>
-            <div class="footer-section"><h4>Company</h4><a href="about.html">About Us</a><a href="careers.html">Careers</a><a href="resources.html">Blog</a><a href="specials.html">Specials</a><a href="financing.html">Financing</a><a href="faq.html">FAQ</a><a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a><a href="/blog/hvac-cost-guide.html">Cost Guide</a></div>
+            <div class="footer-section">
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
+                <a href="ac-services.html">Air Conditioning</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
+                <a href="thermostats.html">Thermostats</a>
+            </div>
+            <div class="footer-section">
+                <h4>Offerings</h4>
+                <a href="residential.html">Residential</a>
+                <a href="commercial.html">Commercial</a>
+                <a href="multifamily.html">Multifamily</a>
+                <a href="service-areas.html">Service Areas</a>
+                <a href="reviews.html">Reviews</a>
+            </div>
+            <div class="footer-section">
+                <h4>Our Story</h4>
+                <a href="about.html">About Air Express</a>
+                <a href="careers.html">Careers</a>
+                <a href="resources.html">Resources & Tips</a>
+                <a href="specials.html">Seasonal Specials</a>
+                <a href="financing.html">Financing</a>
+            </div>
+        </div>
+        <div class="social-icons">
+            <a href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
+            <a href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
+            <a href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
+            <a href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
         </div>
         <div class="payment-options">
             <span>Payment Options:</span>
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
-        <div class="footer-bottom"><p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved.</p></div>
+        <div class="footer-bottom">
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
+        </div>
     </footer>
 <button class="back-to-top" aria-label="Back to top"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="18 15 12 9 6 15"></polyline></svg></button>
 <script src="nav.js" defer></script>

--- a/ac-repair-eagle-mountain-ut.html
+++ b/ac-repair-eagle-mountain-ut.html
@@ -319,12 +319,19 @@
     <footer>
         <div class="footer-content">
             <div class="footer-section">
-                <h3>Services</h3>
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
                 <a href="ac-services.html">Air Conditioning</a>
-                <a href="heating-services.html">Furnace & Heating</a>
-                <a href="heat-pump.html">Heat Pumps</a>
-                <a href="ventilation.html">Ventilation & ERV</a>
-                <a href="air-filters.html">Air Filters</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
                 <a href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">
@@ -340,9 +347,6 @@
                 <a href="about.html">About Air Express</a>
                 <a href="careers.html">Careers</a>
                 <a href="resources.html">Resources & Tips</a>
-                <a href="faq.html">FAQ</a>
-                <a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a href="/blog/hvac-cost-guide.html">Cost Guide</a>
                 <a href="specials.html">Seasonal Specials</a>
                 <a href="financing.html">Financing</a>
             </div>
@@ -358,9 +362,9 @@
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-<button class="back-to-top" aria-label="Back to top" title="Back to top">
+    </footer><button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>
 <script src="nav.js" defer></script>

--- a/ac-repair-lehi-ut.html
+++ b/ac-repair-lehi-ut.html
@@ -316,12 +316,19 @@
     <footer>
         <div class="footer-content">
             <div class="footer-section">
-                <h3>Services</h3>
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
                 <a href="ac-services.html">Air Conditioning</a>
-                <a href="heating-services.html">Furnace & Heating</a>
-                <a href="heat-pump.html">Heat Pumps</a>
-                <a href="ventilation.html">Ventilation & ERV</a>
-                <a href="air-filters.html">Air Filters</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
                 <a href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">
@@ -337,9 +344,6 @@
                 <a href="about.html">About Air Express</a>
                 <a href="careers.html">Careers</a>
                 <a href="resources.html">Resources & Tips</a>
-                <a href="faq.html">FAQ</a>
-                <a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a href="/blog/hvac-cost-guide.html">Cost Guide</a>
                 <a href="specials.html">Seasonal Specials</a>
                 <a href="financing.html">Financing</a>
             </div>
@@ -355,9 +359,9 @@
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-<button class="back-to-top" aria-label="Back to top" title="Back to top">
+    </footer><button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>
 <script src="nav.js" defer></script>

--- a/ac-repair-orem-ut.html
+++ b/ac-repair-orem-ut.html
@@ -316,12 +316,19 @@
     <footer>
         <div class="footer-content">
             <div class="footer-section">
-                <h3>Services</h3>
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
                 <a href="ac-services.html">Air Conditioning</a>
-                <a href="heating-services.html">Furnace & Heating</a>
-                <a href="heat-pump.html">Heat Pumps</a>
-                <a href="ventilation.html">Ventilation & ERV</a>
-                <a href="air-filters.html">Air Filters</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
                 <a href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">
@@ -337,9 +344,6 @@
                 <a href="about.html">About Air Express</a>
                 <a href="careers.html">Careers</a>
                 <a href="resources.html">Resources & Tips</a>
-                <a href="faq.html">FAQ</a>
-                <a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a href="/blog/hvac-cost-guide.html">Cost Guide</a>
                 <a href="specials.html">Seasonal Specials</a>
                 <a href="financing.html">Financing</a>
             </div>
@@ -355,9 +359,9 @@
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-<button class="back-to-top" aria-label="Back to top" title="Back to top">
+    </footer><button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>
 <script src="nav.js" defer></script>

--- a/ac-repair-sandy-ut.html
+++ b/ac-repair-sandy-ut.html
@@ -316,12 +316,19 @@
     <footer>
         <div class="footer-content">
             <div class="footer-section">
-                <h3>Services</h3>
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
                 <a href="ac-services.html">Air Conditioning</a>
-                <a href="heating-services.html">Furnace & Heating</a>
-                <a href="heat-pump.html">Heat Pumps</a>
-                <a href="ventilation.html">Ventilation & ERV</a>
-                <a href="air-filters.html">Air Filters</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
                 <a href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">
@@ -337,9 +344,6 @@
                 <a href="about.html">About Air Express</a>
                 <a href="careers.html">Careers</a>
                 <a href="resources.html">Resources & Tips</a>
-                <a href="faq.html">FAQ</a>
-                <a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a href="/blog/hvac-cost-guide.html">Cost Guide</a>
                 <a href="specials.html">Seasonal Specials</a>
                 <a href="financing.html">Financing</a>
             </div>
@@ -355,9 +359,9 @@
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-<button class="back-to-top" aria-label="Back to top" title="Back to top">
+    </footer><button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>
 <script src="nav.js" defer></script>

--- a/ac-repair-saratoga-springs-ut.html
+++ b/ac-repair-saratoga-springs-ut.html
@@ -302,16 +302,23 @@
     <footer>
         <div class="footer-content">
             <div class="footer-section">
-                <h3>Services</h3>
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
                 <a href="ac-services.html">Air Conditioning</a>
-                <a href="heating-services.html">Furnace & Heating</a>
-                <a href="heat-pump.html">Heat Pumps</a>
-                <a href="ventilation.html">Ventilation</a>
-                <a href="air-filters.html">Air Filters</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
                 <a href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">
-                <h4>Community</h4>
+                <h4>Offerings</h4>
                 <a href="residential.html">Residential</a>
                 <a href="commercial.html">Commercial</a>
                 <a href="multifamily.html">Multifamily</a>
@@ -319,26 +326,26 @@
                 <a href="reviews.html">Reviews</a>
             </div>
             <div class="footer-section">
-                <h4>Company</h4>
-                <a href="about.html">About Us</a>
+                <h4>Our Story</h4>
+                <a href="about.html">About Air Express</a>
                 <a href="careers.html">Careers</a>
-                <a href="resources.html">Blog</a>
-                <a href="specials.html">Specials</a>
-                <a href="financing.html">Financing</a><a href="faq.html">FAQ</a><a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a><a href="/blog/hvac-cost-guide.html">Cost Guide</a>
+                <a href="resources.html">Resources & Tips</a>
+                <a href="specials.html">Seasonal Specials</a>
+                <a href="financing.html">Financing</a>
             </div>
         </div>
         <div class="social-icons">
-            <a href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"></a>
-            <a href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"></a>
-            <a href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"></a>
-            <a href="https://youtube.com" aria-label="YouTube"></a>
+            <a href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
+            <a href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
+            <a href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
+            <a href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
         </div>
         <div class="payment-options">
             <span>Payment Options:</span>
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved.</p>
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
     </footer>
 <button class="back-to-top" aria-label="Back to top">

--- a/ac-repair.html
+++ b/ac-repair.html
@@ -137,7 +137,7 @@
         <section class="section">
             <div class="two-col">
                 <div>
-                    <img src="images/ac-repair-utah.webp" alt="AC repair technician" loading="lazy">
+                    <img src="images/ac-repair-utah-1200.webp" srcset="images/ac-repair-utah-1200.webp 1200w, images/ac-repair-utah-1800.webp 1800w" sizes="(max-width: 900px) 100vw, 50vw" alt="AC repair technician" loading="lazy">
                 </div>
                 <div>
                     <h2 class="section-title">Same-Day Emergency Repair</h2>

--- a/ac-services.html
+++ b/ac-services.html
@@ -185,7 +185,7 @@
                     </ul>
                     <p style="margin-top: 20px;">Schedule now, before heat season. It's the best investment in peace of mind.</p>
                 </div>
-                <img src="images/maintenance-coil-utah.webp" alt="HVAC technician performing AC maintenance" loading="lazy">
+                <img src="images/maintenance-coil-utah-1200.webp" srcset="images/maintenance-coil-utah-1200.webp 1200w, images/maintenance-coil-utah-1800.webp 1800w" sizes="(max-width: 900px) 100vw, 50vw" alt="HVAC technician performing AC maintenance" loading="lazy">
             </div>
         </section>
 

--- a/air-filters.html
+++ b/air-filters.html
@@ -192,7 +192,7 @@
                     </ul>
                     <p>Regular changes every 1–3 months prevent all of it. It's the simplest, cheapest maintenance you can do.</p>
                 </div>
-                <img src="images/maintenance-ducts-utah.webp" alt="HVAC technician performing filter maintenance" loading="lazy">
+                <img src="images/maintenance-ducts-utah-1200.webp" srcset="images/maintenance-ducts-utah-1200.webp 1200w, images/maintenance-ducts-utah-1800.webp 1800w" sizes="(max-width: 900px) 100vw, 50vw" alt="HVAC technician performing filter maintenance" loading="lazy">
             </div>
         </section>
 

--- a/commercial.html
+++ b/commercial.html
@@ -117,7 +117,7 @@
             <p class="section-subtitle">Your HVAC system keeps customers comfortable, employees productive, and operations running. We've served Utah County businesses for three decades. Uptime is our priority.</p>
 
             <div class="two-col">
-                <img src="images/commercial-utah.webp" alt="Commercial HVAC system" loading="lazy">
+                <img src="images/commercial-utah-1200.webp" srcset="images/commercial-utah-1200.webp 1200w, images/commercial-utah-1800.webp 1800w" sizes="(max-width: 900px) 100vw, 50vw" alt="Commercial HVAC system" loading="lazy">
                 <div>
                     <h3>Built for Business</h3>
                     <ul>

--- a/dehumidifiers.html
+++ b/dehumidifiers.html
@@ -122,7 +122,7 @@
                 <p class="hero-subtitle">Professional DV Series Dehumidifier Services</p>
             </div>
             <div class="hero-image">
-                <img src="images/dehumidifier-utah.webp" alt="Whole-home dehumidifier installed in a Utah residential basement utility room" loading="lazy">
+                <img src="images/dehumidifier-utah-1200.webp" srcset="images/dehumidifier-utah-1200.webp 1200w, images/dehumidifier-utah-1800.webp 1800w" sizes="(max-width: 900px) 100vw, 50vw" alt="Whole-home dehumidifier installed in a Utah residential basement utility room" loading="lazy">
             </div>
         </section>
 

--- a/emergency.html
+++ b/emergency.html
@@ -114,7 +114,7 @@
 
         <section class="section">
             <div class="two-col">
-                <img src="images/emergency-utah.webp" alt="Air Express HVAC technician arriving at a Utah home for an emergency call at dusk with the Wasatch Mountains in the background" loading="lazy">
+                <img src="images/emergency-utah-1200.webp" srcset="images/emergency-utah-1200.webp 1200w, images/emergency-utah-1800.webp 1800w" sizes="(max-width: 900px) 100vw, 50vw" alt="Air Express HVAC technician arriving at a Utah home for an emergency call at dusk with the Wasatch Mountains in the background" loading="lazy">
                 <div>
                     <h2>Available When You Need Us Most</h2>
                     <p>HVAC emergencies don't happen during business hours. When your heat dies in January or your AC fails in July, we respond fast with same-day service.</p>

--- a/filtration.html
+++ b/filtration.html
@@ -102,7 +102,7 @@
             <div class="hero-content">
                 <h1>Filtration Services In Lehi, UT</h1>
             </div>
-            <img src="images/filtration-utah.webp" alt="HVAC technician replacing a fresh pleated air filter in a Utah home furnace" loading="lazy">
+            <img src="images/filtration-utah-1200.webp" srcset="images/filtration-utah-1200.webp 1200w, images/filtration-utah-1800.webp 1800w" sizes="(max-width: 900px) 100vw, 50vw" alt="HVAC technician replacing a fresh pleated air filter in a Utah home furnace" loading="lazy">
         </section>
 
         <section class="content-section">

--- a/furnace-repair-eagle-mountain-ut.html
+++ b/furnace-repair-eagle-mountain-ut.html
@@ -306,12 +306,19 @@
     <footer>
         <div class="footer-content">
             <div class="footer-section">
-                <h3>Services</h3>
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
                 <a href="ac-services.html">Air Conditioning</a>
-                <a href="heating-services.html">Furnace & Heating</a>
-                <a href="heat-pump.html">Heat Pumps</a>
-                <a href="ventilation.html">Ventilation & ERV</a>
-                <a href="air-filters.html">Air Filters</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
                 <a href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">
@@ -327,9 +334,6 @@
                 <a href="about.html">About Air Express</a>
                 <a href="careers.html">Careers</a>
                 <a href="resources.html">Resources & Tips</a>
-                <a href="faq.html">FAQ</a>
-                <a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a href="/blog/hvac-cost-guide.html">Cost Guide</a>
                 <a href="specials.html">Seasonal Specials</a>
                 <a href="financing.html">Financing</a>
             </div>
@@ -345,7 +349,7 @@
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
     </footer>
 <button class="back-to-top" aria-label="Back to top" title="Back to top">

--- a/furnace-repair-lehi-ut.html
+++ b/furnace-repair-lehi-ut.html
@@ -316,12 +316,19 @@
     <footer>
         <div class="footer-content">
             <div class="footer-section">
-                <h3>Services</h3>
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
                 <a href="ac-services.html">Air Conditioning</a>
-                <a href="heating-services.html">Furnace & Heating</a>
-                <a href="heat-pump.html">Heat Pumps</a>
-                <a href="ventilation.html">Ventilation & ERV</a>
-                <a href="air-filters.html">Air Filters</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
                 <a href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">
@@ -337,9 +344,6 @@
                 <a href="about.html">About Air Express</a>
                 <a href="careers.html">Careers</a>
                 <a href="resources.html">Resources & Tips</a>
-                <a href="faq.html">FAQ</a>
-                <a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a href="/blog/hvac-cost-guide.html">Cost Guide</a>
                 <a href="specials.html">Seasonal Specials</a>
                 <a href="financing.html">Financing</a>
             </div>
@@ -355,9 +359,9 @@
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-<button class="back-to-top" aria-label="Back to top" title="Back to top">
+    </footer><button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>
 <script src="nav.js" defer></script>

--- a/furnace-repair-orem-ut.html
+++ b/furnace-repair-orem-ut.html
@@ -316,12 +316,19 @@
     <footer>
         <div class="footer-content">
             <div class="footer-section">
-                <h3>Services</h3>
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
                 <a href="ac-services.html">Air Conditioning</a>
-                <a href="heating-services.html">Furnace & Heating</a>
-                <a href="heat-pump.html">Heat Pumps</a>
-                <a href="ventilation.html">Ventilation & ERV</a>
-                <a href="air-filters.html">Air Filters</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
                 <a href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">
@@ -337,9 +344,6 @@
                 <a href="about.html">About Air Express</a>
                 <a href="careers.html">Careers</a>
                 <a href="resources.html">Resources & Tips</a>
-                <a href="faq.html">FAQ</a>
-                <a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a href="/blog/hvac-cost-guide.html">Cost Guide</a>
                 <a href="specials.html">Seasonal Specials</a>
                 <a href="financing.html">Financing</a>
             </div>
@@ -355,9 +359,9 @@
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-<button class="back-to-top" aria-label="Back to top" title="Back to top">
+    </footer><button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>
 <script src="nav.js" defer></script>

--- a/furnace-repair-sandy-ut.html
+++ b/furnace-repair-sandy-ut.html
@@ -316,12 +316,19 @@
     <footer>
         <div class="footer-content">
             <div class="footer-section">
-                <h3>Services</h3>
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
                 <a href="ac-services.html">Air Conditioning</a>
-                <a href="heating-services.html">Furnace & Heating</a>
-                <a href="heat-pump.html">Heat Pumps</a>
-                <a href="ventilation.html">Ventilation & ERV</a>
-                <a href="air-filters.html">Air Filters</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
                 <a href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">
@@ -337,9 +344,6 @@
                 <a href="about.html">About Air Express</a>
                 <a href="careers.html">Careers</a>
                 <a href="resources.html">Resources & Tips</a>
-                <a href="faq.html">FAQ</a>
-                <a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a href="/blog/hvac-cost-guide.html">Cost Guide</a>
                 <a href="specials.html">Seasonal Specials</a>
                 <a href="financing.html">Financing</a>
             </div>
@@ -355,9 +359,9 @@
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-<button class="back-to-top" aria-label="Back to top" title="Back to top">
+    </footer><button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>
 <script src="nav.js" defer></script>

--- a/furnace-repair-saratoga-springs-ut.html
+++ b/furnace-repair-saratoga-springs-ut.html
@@ -253,16 +253,23 @@
     <footer>
         <div class="footer-content">
             <div class="footer-section">
-                <h3>Services</h3>
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
                 <a href="ac-services.html">Air Conditioning</a>
-                <a href="heating-services.html">Furnace & Heating</a>
-                <a href="heat-pump.html">Heat Pumps</a>
-                <a href="ventilation.html">Ventilation</a>
-                <a href="air-filters.html">Air Filters</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
                 <a href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">
-                <h4>Community</h4>
+                <h4>Offerings</h4>
                 <a href="residential.html">Residential</a>
                 <a href="commercial.html">Commercial</a>
                 <a href="multifamily.html">Multifamily</a>
@@ -270,26 +277,26 @@
                 <a href="reviews.html">Reviews</a>
             </div>
             <div class="footer-section">
-                <h4>Company</h4>
-                <a href="about.html">About Us</a>
+                <h4>Our Story</h4>
+                <a href="about.html">About Air Express</a>
                 <a href="careers.html">Careers</a>
-                <a href="resources.html">Blog</a>
-                <a href="specials.html">Specials</a>
-                <a href="financing.html">Financing</a><a href="faq.html">FAQ</a><a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a><a href="/blog/hvac-cost-guide.html">Cost Guide</a>
+                <a href="resources.html">Resources & Tips</a>
+                <a href="specials.html">Seasonal Specials</a>
+                <a href="financing.html">Financing</a>
             </div>
         </div>
         <div class="social-icons">
-            <a href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"></a>
-            <a href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"></a>
-            <a href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"></a>
-            <a href="https://youtube.com" aria-label="YouTube"></a>
+            <a href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
+            <a href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
+            <a href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
+            <a href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
         </div>
         <div class="payment-options">
             <span>Payment Options:</span>
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved.</p>
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
     </footer>
 <button class="back-to-top" aria-label="Back to top">

--- a/heating-installation-eagle-mountain-ut.html
+++ b/heating-installation-eagle-mountain-ut.html
@@ -250,16 +250,23 @@
     <footer>
         <div class="footer-content">
             <div class="footer-section">
-                <h3>Services</h3>
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
                 <a href="ac-services.html">Air Conditioning</a>
-                <a href="heating-services.html">Furnace & Heating</a>
-                <a href="heat-pump.html">Heat Pumps</a>
-                <a href="ventilation.html">Ventilation</a>
-                <a href="air-filters.html">Air Filters</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
                 <a href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">
-                <h4>Community</h4>
+                <h4>Offerings</h4>
                 <a href="residential.html">Residential</a>
                 <a href="commercial.html">Commercial</a>
                 <a href="multifamily.html">Multifamily</a>
@@ -267,26 +274,26 @@
                 <a href="reviews.html">Reviews</a>
             </div>
             <div class="footer-section">
-                <h4>Company</h4>
-                <a href="about.html">About Us</a>
+                <h4>Our Story</h4>
+                <a href="about.html">About Air Express</a>
                 <a href="careers.html">Careers</a>
-                <a href="resources.html">Blog</a>
-                <a href="specials.html">Specials</a>
-                <a href="financing.html">Financing</a><a href="faq.html">FAQ</a><a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a><a href="/blog/hvac-cost-guide.html">Cost Guide</a>
+                <a href="resources.html">Resources & Tips</a>
+                <a href="specials.html">Seasonal Specials</a>
+                <a href="financing.html">Financing</a>
             </div>
         </div>
         <div class="social-icons">
-            <a href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"></a>
-            <a href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"></a>
-            <a href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"></a>
-            <a href="https://youtube.com" aria-label="YouTube"></a>
+            <a href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
+            <a href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
+            <a href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
+            <a href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
         </div>
         <div class="payment-options">
             <span>Payment Options:</span>
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved.</p>
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
     </footer>
 <button class="back-to-top" aria-label="Back to top">

--- a/heating-installation-lehi-ut.html
+++ b/heating-installation-lehi-ut.html
@@ -316,12 +316,19 @@
     <footer>
         <div class="footer-content">
             <div class="footer-section">
-                <h3>Services</h3>
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
                 <a href="ac-services.html">Air Conditioning</a>
-                <a href="heating-services.html">Furnace & Heating</a>
-                <a href="heat-pump.html">Heat Pumps</a>
-                <a href="ventilation.html">Ventilation & ERV</a>
-                <a href="air-filters.html">Air Filters</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
                 <a href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">
@@ -337,9 +344,6 @@
                 <a href="about.html">About Air Express</a>
                 <a href="careers.html">Careers</a>
                 <a href="resources.html">Resources & Tips</a>
-                <a href="faq.html">FAQ</a>
-                <a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a href="/blog/hvac-cost-guide.html">Cost Guide</a>
                 <a href="specials.html">Seasonal Specials</a>
                 <a href="financing.html">Financing</a>
             </div>
@@ -355,9 +359,9 @@
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-<button class="back-to-top" aria-label="Back to top" title="Back to top">
+    </footer><button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>
 <script src="nav.js" defer></script>

--- a/heating-installation-orem-ut.html
+++ b/heating-installation-orem-ut.html
@@ -316,12 +316,19 @@
     <footer>
         <div class="footer-content">
             <div class="footer-section">
-                <h3>Services</h3>
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
                 <a href="ac-services.html">Air Conditioning</a>
-                <a href="heating-services.html">Furnace & Heating</a>
-                <a href="heat-pump.html">Heat Pumps</a>
-                <a href="ventilation.html">Ventilation & ERV</a>
-                <a href="air-filters.html">Air Filters</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
                 <a href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">
@@ -337,9 +344,6 @@
                 <a href="about.html">About Air Express</a>
                 <a href="careers.html">Careers</a>
                 <a href="resources.html">Resources & Tips</a>
-                <a href="faq.html">FAQ</a>
-                <a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a href="/blog/hvac-cost-guide.html">Cost Guide</a>
                 <a href="specials.html">Seasonal Specials</a>
                 <a href="financing.html">Financing</a>
             </div>
@@ -355,9 +359,9 @@
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-<button class="back-to-top" aria-label="Back to top" title="Back to top">
+    </footer><button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>
 <script src="nav.js" defer></script>

--- a/heating-installation-sandy-ut.html
+++ b/heating-installation-sandy-ut.html
@@ -316,12 +316,19 @@
     <footer>
         <div class="footer-content">
             <div class="footer-section">
-                <h3>Services</h3>
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
                 <a href="ac-services.html">Air Conditioning</a>
-                <a href="heating-services.html">Furnace & Heating</a>
-                <a href="heat-pump.html">Heat Pumps</a>
-                <a href="ventilation.html">Ventilation & ERV</a>
-                <a href="air-filters.html">Air Filters</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
                 <a href="thermostats.html">Thermostats</a>
             </div>
             <div class="footer-section">
@@ -337,9 +344,6 @@
                 <a href="about.html">About Air Express</a>
                 <a href="careers.html">Careers</a>
                 <a href="resources.html">Resources & Tips</a>
-                <a href="faq.html">FAQ</a>
-                <a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a>
-                <a href="/blog/hvac-cost-guide.html">Cost Guide</a>
                 <a href="specials.html">Seasonal Specials</a>
                 <a href="financing.html">Financing</a>
             </div>
@@ -355,9 +359,9 @@
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
         </div>
-<button class="back-to-top" aria-label="Back to top" title="Back to top">
+    </footer><button class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
 </button>
 <script src="nav.js" defer></script>

--- a/heating-installation-saratoga-springs-ut.html
+++ b/heating-installation-saratoga-springs-ut.html
@@ -227,15 +227,52 @@
 
     <footer>
         <div class="footer-content">
-            <div class="footer-section"><h3>Services</h3><a href="ac-services.html">Air Conditioning</a><a href="heat-pump.html">Furnace & Heating</a><a href="heat-pump.html">Heat Pumps</a><a href="ventilation.html">Ventilation</a><a href="air-filters.html">Air Filters</a><a href="thermostats.html">Thermostats</a></div>
-            <div class="footer-section"><h4>Community</h4><a href="residential.html">Residential</a><a href="commercial.html">Commercial</a><a href="multifamily.html">Multifamily</a><a href="service-areas.html">Service Areas</a><a href="reviews.html">Reviews</a></div>
-            <div class="footer-section"><h4>Company</h4><a href="about.html">About Us</a><a href="careers.html">Careers</a><a href="resources.html">Blog</a><a href="specials.html">Specials</a><a href="financing.html">Financing</a><a href="faq.html">FAQ</a><a href="/blog/hvac-buying-guide.html">HVAC Buying Guide</a><a href="/blog/hvac-cost-guide.html">Cost Guide</a></div>
+            <div class="footer-section">
+                <h3>License #96-324211-550 | Contact Us</h3>
+                <p><strong>(801) 766-8585</strong></p>
+                <p>628 E State St Ste 1, Lehi, UT 84043</p>
+                <p><a href="contact.html">Get a Free Estimate</a></p>
+                <p><a href="emergency.html">24/7 Emergency Service</a></p>
+            </div>
+            <div class="footer-section">
+                <h4>Services</h4>
+                <a href="ac-services.html">Air Conditioning</a>
+                <a href="heat-pump.html">Heating & Heat Pumps</a>
+                <a href="ventilation.html">Air Quality</a>
+                <a href="ductwork.html">Ductwork</a>
+                            <a href="gas-lines.html">Gas Lines</a>
+                <a href="thermostats.html">Thermostats</a>
+            </div>
+            <div class="footer-section">
+                <h4>Offerings</h4>
+                <a href="residential.html">Residential</a>
+                <a href="commercial.html">Commercial</a>
+                <a href="multifamily.html">Multifamily</a>
+                <a href="service-areas.html">Service Areas</a>
+                <a href="reviews.html">Reviews</a>
+            </div>
+            <div class="footer-section">
+                <h4>Our Story</h4>
+                <a href="about.html">About Air Express</a>
+                <a href="careers.html">Careers</a>
+                <a href="resources.html">Resources & Tips</a>
+                <a href="specials.html">Seasonal Specials</a>
+                <a href="financing.html">Financing</a>
+            </div>
+        </div>
+        <div class="social-icons">
+            <a href="https://www.facebook.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Facebook"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></span></a>
+            <a href="https://www.instagram.com/airexpresshvac/" target="_blank" rel="noopener" aria-label="Instagram"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><rect x="2.4" y="2.4" width="19.2" height="19.2" rx="4.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3.6" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="18.5" cy="5.5" r="1.5" fill="currentColor"/></svg></span></a>
+            <a href="https://g.page/r/CYZKv5H3bwNzEBM/review" target="_blank" rel="noopener" aria-label="Google Reviews"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118l2.251-.637zM18.807 9.73c-.553-1.73-2.01-3.164-3.88-3.848.26.17.496.405.709.71-.168.02-.33.061-.49.119 1.563.265 2.863 1.273 3.548 2.679-.5-.263-.968-.504-1.405-.725.03.086.057.172.085.258zM5.697 9.956c.56-.606 1.423-1.002 2.364-1.002.894 0 1.714.323 2.324.847-.656-.211-1.26-.562-1.77-1.032.195.258.435.473.716.636-.283-.084-.544-.213-.776-.377.263.787.775 1.453 1.428 1.967-.44-.129-.856-.338-1.229-.606.398.644.942 1.204 1.573 1.629-.187-.06-.358-.155-.513-.268.515.993 1.423 1.813 2.508 2.306-1.074-.328-2.05-1.027-2.76-1.916.64.625 1.484 1.063 2.422 1.193-.295-.297-.495-.708-.495-1.16 0-.383.098-.746.271-1.06.618.94 1.615 1.612 2.788 1.708-.096-.438-.164-.9-.164-1.378 0-2.106 1.708-3.814 3.814-3.814.5 0 .982.094 1.425.273-.21-1.218-.987-2.308-2.026-2.965.684.2 1.327.541 1.9 1.016-.26-.37-.597-.686-.996-.943.607-.236 1.16-.57 1.656-.994zM12.322 17.78c-1.092 0-2.1-.289-2.977-.776.378.03.758.046 1.143.046 2.916 0 5.494-1.466 7.036-3.694.637.858 1.437 1.567 2.356 2.067-.685.46-1.486.776-2.361.916.37.266.704.589.988.96-.804.118-1.586.184-2.389.184zm6.03-4.06c-1.214 0-2.297.637-2.917 1.59.374-.043.754-.066 1.14-.066 1.72 0 3.307.504 4.656 1.375-.465-1.167-1.54-2.12-2.879-2.9zM3.97 8.963c.82 0 1.571.257 2.197.688-.54-.17-1.108-.265-1.695-.265-.98 0-1.896.24-2.698.66.56-.334 1.218-.545 1.924-.716.11-.02.22-.035.33-.047.016-.001.032-.002.048-.002z" opacity=".3"/><path fill="currentColor" d="M23.953 4.57a10 10 0 002.856 2.905c-.674-.375-1.39-.688-2.129-.906.64.15 1.247.391 1.805.717-.527-1.79-1.56-3.32-3.072-4.555.289.391.635.654 1.1 1.07.03.034.075.076.119.118zm-1.79 10.638c-.067.01-.136.023-.203.039.066-.013.136-.028.203-.039zm4.692-2.142c-.846 2.478-2.837 4.493-5.28 5.047.78-.46 1.487-1.063 2.081-1.784-.563.089-1.131.276-1.675.511l.313-.628c-1.125.687-2.505 1.084-3.99 1.084-4.595 0-8.331-3.736-8.331-8.331 0-.981.169-1.922.485-2.8-3.028 1.658-5.537 4.649-6.164 8.213-.139.787-.213 1.584-.213 2.405C1 21.627 5.373 25 12 25c5.608 0 10.357-3.86 11.605-9.05-.184-.07-.365-.131-.549-.19.666-1.113 1.075-2.408 1.075-3.76 0-.746-.111-1.467-.325-2.157"/></svg></span></a>
+            <a href="https://youtube.com" aria-label="YouTube"><span class="icon-svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg></span></a>
         </div>
         <div class="payment-options">
             <span>Payment Options:</span>
             <span class="payment-icons">Visa | Mastercard | Discover | Amex | Check | Cash</span>
         </div>
-        <div class="footer-bottom"><p>&copy; 2026 Air Express Heating & Air Conditioning. All rights reserved.</p></div>
+        <div class="footer-bottom">
+            <p>&copy; 2026 Air Express HVAC. All rights reserved. | <a href="privacy-policy.html" style="color: inherit;">Privacy Policy</a> | <a href="terms-of-service.html" style="color: inherit;">Terms of Service</a></p>
+        </div>
     </footer>
 <button class="back-to-top" aria-label="Back to top"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="18 15 12 9 6 15"></polyline></svg></button>
 <script src="nav.js" defer></script>

--- a/heating-services.html
+++ b/heating-services.html
@@ -117,7 +117,7 @@
         <!-- ============ STORY / OPENING ============ -->
         <section class="section">
             <div class="two-col">
-                <img src="images/winter-heating-troubleshooting.webp" width="800" height="600" alt="Air Express HVAC technician troubleshooting a Carrier furnace in a Utah residential basement during winter" loading="lazy">
+                <img src="images/winter-heating-troubleshooting-1200.webp" srcset="images/winter-heating-troubleshooting-1200.webp 1200w, images/winter-heating-troubleshooting-1800.webp 1800w" sizes="(max-width: 900px) 100vw, 50vw" width="800" height="600" alt="Air Express HVAC technician troubleshooting a Carrier furnace in a Utah residential basement during winter" loading="lazy">
                 <div>
                     <h2>Utah winters don't care about your schedule.</h2>
                     <p>The first call we get every December is the same: someone flipped the thermostat from cool to heat for the first time, and nothing happened. Or the burners ignite for ten seconds and then quit. Or the blower runs but the air comes out cold.</p>
@@ -202,7 +202,7 @@
                     </ul>
                     <p style="margin-top: 20px;">Schedule now, before winter hits. It's the best investment in reliability.</p>
                 </div>
-                <img src="images/maintenance-furnace-utah.webp" alt="HVAC maintenance and inspection" loading="lazy">
+                <img src="images/maintenance-furnace-utah-1200.webp" srcset="images/maintenance-furnace-utah-1200.webp 1200w, images/maintenance-furnace-utah-1800.webp 1800w" sizes="(max-width: 900px) 100vw, 50vw" alt="HVAC maintenance and inspection" loading="lazy">
             </div>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
         </section>
 
         <figure class="full-width-image">
-            <img src="images/trust-porch-utah.webp" width="1024" height="768" alt="Air Express HVAC technician greeting a Utah homeowner at her front door with the Wasatch Mountains in the background" loading="lazy">
+            <img src="images/trust-porch-utah-1200.webp" srcset="images/trust-porch-utah-1200.webp 1200w, images/trust-porch-utah-1800.webp 1800w" sizes="(max-width: 900px) 100vw, 50vw" width="1024" height="768" alt="Air Express HVAC technician greeting a Utah homeowner at her front door with the Wasatch Mountains in the background" loading="lazy">
         </figure>
 
         <!-- WHY CHOOSE US -->

--- a/multifamily.html
+++ b/multifamily.html
@@ -117,7 +117,7 @@
             <p class="section-subtitle">Multifamily HVAC needs coordinated service, clear communication, and proactive maintenance. We've served Utah County apartment complexes for three decades. Resident satisfaction is our priority.</p>
 
             <div class="two-col">
-                <img src="images/multifamily-utah.webp" width="800" height="800" alt="Multifamily apartment complex" loading="lazy">
+                <img src="images/multifamily-utah-1200.webp" srcset="images/multifamily-utah-1200.webp 1200w, images/multifamily-utah-1800.webp 1800w" sizes="(max-width: 900px) 100vw, 50vw" width="800" height="800" alt="Multifamily apartment complex" loading="lazy">
                 <div>
                     <h3>Built for Properties</h3>
                     <ul>

--- a/residential.html
+++ b/residential.html
@@ -117,7 +117,7 @@
             <p class="section-subtitle">For three decades, Utah families have trusted us to keep them comfortable through the coldest winters and the hottest summers in the valley.</p>
 
             <div class="two-col">
-                <img src="images/family-comfort-utah.webp" width="800" height="800" alt="Happy family in their home" loading="lazy">
+                <img src="images/family-comfort-utah-1200.webp" srcset="images/family-comfort-utah-1200.webp 1200w, images/family-comfort-utah-1800.webp 1800w" sizes="(max-width: 900px) 100vw, 50vw" width="800" height="800" alt="Happy family in their home" loading="lazy">
                 <div>
                     <h3>Neighbors Serving Neighbors</h3>
                     <ul>
@@ -192,7 +192,7 @@
                         <li>280+ five-star reviews from neighbors like you</li>
                     </ul>
                 </div>
-                <img src="images/residential-utah.webp" width="800" height="800" alt="Residential home with HVAC service" loading="lazy">
+                <img src="images/residential-utah-1200.webp" srcset="images/residential-utah-1200.webp 1200w, images/residential-utah-1800.webp 1800w" sizes="(max-width: 900px) 100vw, 50vw" width="800" height="800" alt="Residential home with HVAC service" loading="lazy">
             </div>
         </section>
 

--- a/ventilation.html
+++ b/ventilation.html
@@ -191,7 +191,7 @@
                         <li>Works harder the more extreme the season</li>
                     </ul>
                 </div>
-                <img src="images/maintenance-ducts-utah.webp" alt="HVAC technician checking ventilation system" loading="lazy">
+                <img src="images/maintenance-ducts-utah-1200.webp" srcset="images/maintenance-ducts-utah-1200.webp 1200w, images/maintenance-ducts-utah-1800.webp 1800w" sizes="(max-width: 900px) 100vw, 50vw" alt="HVAC technician checking ventilation system" loading="lazy">
             </div>
         </section>
 


### PR DESCRIPTION
## Why this PR exists

Ran a deep formatting audit to find issues the earlier passes missed. Two prevalent bugs surfaced.

## Bug 1 — 15 body images not loading responsive variants

13 source images already had `-1200.webp` + `-1800.webp` responsive variants shipped on disk, but their `<img>` tags were still loading the full-size original. Every viewport was paying desktop bandwidth for every image.

**Fix:** upgraded 15 `<img>` tags across 14 pages to use proper `srcset` + `sizes` + mobile-first `src` fallback.

Affected pages: `ac-repair`, `ac-services`, `air-filters`, `about`, `commercial`, `dehumidifiers`, `emergency`, `filtration`, `heating-services`, `index`, `multifamily`, `residential`, `ventilation`.

Sweep: `/tmp/add_srcset_sweep.py`.

## Bug 2 — 20 fat geo pages missing an entire footer column

All 20 `ac-repair-*-ut`, `ac-installation-*-ut`, `furnace-repair-*-ut`, and `heating-installation-*-ut` pages were **missing the first footer column entirely** — the `License #96-324211-550 | Contact Us` block with phone, address, Free Estimate link, and Emergency Service link.

Users landing on any of these pages via SEO saw **zero trust signals in the footer** — no phone number, no address, no emergency link.

Additional footer drift on the same 20 pages:
- "Services" heading was `<h3>` instead of canonical `<h4>` (hierarchy mismatch with the other columns)
- Copyright said _"Air Express Heating & Air Conditioning"_ instead of canonical _"Air Express HVAC"_
- **13 of the 20 pages had broken HTML** — `<footer>` opening tag with **no closing `</footer>`**, a legacy bug from my earlier Phase 5C duplicate-footer cleanup that trimmed the wrong end

**Fix:** replaced the entire `<footer>...</footer>` block on all 20 pages with the canonical footer copied verbatim from `index.html`. The sweep handled both well-formed and broken-HTML cases via a regex that matches either `</footer>` or the terminating `<div class="footer-bottom">` immediately before `<button class="back-to-top">`.

Sweep: `/tmp/normalize_footer.py`.

## Audit findings not fixed in this PR (by design)

- **37 pages** have meta descriptions > 160 chars — SEO concern, not a formatting issue
- **19 legacy pages** exist as rewrite targets in `vercel.json` but aren't linked from anywhere in the site — intentional for backlink preservation
- **30 body service images** (`ac-installation.webp` etc.) don't have 1200/1800 variants, but they're already 1248×832 px so the mobile bandwidth impact is marginal

## Test plan

- [x] `npx playwright test --project=chromium-desktop tests/e2e/smoke.spec.js` — 14 passed, 1 skipped, 0 failed
- [x] All 20 geo pages now contain `<h3>License #96-324211-550 | Contact Us</h3>`
- [x] All 20 geo pages have balanced `<footer>` / `</footer>` tag pairs (1 open, 1 close each)
- [x] Sample `<img>` tag verified: `ac-repair.html` loads `ac-repair-utah-1200.webp` with srcset going to 1800w variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)