### PR TITLE
Improve Air Express draft blog GEO extractability

### DIFF
--- a/content/blog/fall-furnace-prep.md
+++ b/content/blog/fall-furnace-prep.md
@@ -23,7 +23,11 @@ We've been doing this in Lehi since 1996. We know the rhythm. And we know that a
 
 This is the checklist we actually walk through on a fall tune-up. Not the marketing version with twelve bullet points. The real one — the things that, if you do them in September, will keep your furnace from becoming a crisis in January.
 
-## Swap the filter. For real, not "eventually."
+## What should Utah homeowners check before furnace season?
+
+Before the first cold week, change the filter, test heat mode for a short cycle, check that furnace vents are clear, test carbon monoxide alarms, and make sure supply and return grilles are not blocked. If anything smells unsafe, sounds wrong, or does not heat normally, schedule [furnace maintenance](/furnace-maintenance.html) or [heating repair](/heating-repair.html) before the system becomes urgent.
+
+## What should you check first before furnace season?
 
 The filter is the single thing everyone knows about and almost nobody does on time. Here's what we see when we pull the front panel in October: a filter that should have been changed in June, crusted with dust and pet hair, pulled into a concave dish from being sucked on all summer.
 
@@ -62,7 +66,7 @@ Just walk around your house, find the white PVC pipe coming out of the wall (it'
 
 ## Test your carbon monoxide detector.
 
-Speaking of carbon monoxide: if you don't have a CO detector on every level of your house, stop reading this and go buy some. They're thirty bucks at any hardware store and they will literally save your family's life.
+Speaking of carbon monoxide: if you don't have a CO detector on every level of your house, stop reading this and go buy some. The [U.S. Consumer Product Safety Commission](https://www.cpsc.gov/Safety-Education/Safety-Education-Centers/Carbon-Monoxide-Information-Center/CO-Alarms) recommends CO alarms on each level of the home and outside sleeping areas.
 
 If you already have them, press the test button on each one. If the beep is weak or it doesn't respond at all, replace the batteries or replace the whole unit if it's more than seven years old.
 
@@ -88,11 +92,11 @@ Also know where your main gas shutoff is. It's usually near the gas meter on the
 
 We're not going to pressure you to replace a working furnace. If it's running, it's running.
 
-But here's what we see: furnaces in Utah have a realistic lifespan of 15–20 years. Around year 15, we start seeing the signs — small parts starting to fail, efficiency dropping, repair costs creeping up. By year 20, most systems are running at 60% of their rated efficiency, and you're paying the difference on every utility bill.
+But here's what we see: older furnaces often start needing more parts, more diagnostic time, and more comfort tradeoffs. Around year 15, it is worth comparing repair history, safety condition, comfort, and efficiency before you are forced into a January decision.
 
-If yours is in that zone, the time to plan for replacement is in September or October, when technicians are booked but not slammed, prices haven't spiked, and you can actually shop around. The worst possible time to replace a furnace is the middle of January, when it just failed, it's 12 degrees outside, and you'll take whatever's available.
+If yours is in that zone, the time to plan for replacement is in September or October, when technicians are booked but not slammed and you can actually shop around. The worst possible time to replace a furnace is the middle of January, when it just failed, it's 12 degrees outside, and you'll take whatever's available.
 
-Get a few estimates. Ask what brands the technicians actually install in their own homes. Ask about rebates — Utah has decent ones for high-efficiency systems, and most installers know which ones you qualify for.
+Get a few estimates. Ask what brands the technicians actually install in their own homes. Ask whether current rebates or tax credits apply, and make sure any incentive is verified before you count it in the budget. Air Express can help with [furnace repair](/furnace-repair.html), [heating maintenance](/heating-maintenance.html), and [heating replacement](/heating-replacement.html) planning.
 
 ## The short version
 
@@ -103,8 +107,13 @@ If you do nothing else this fall, do these four things:
 3. **Walk around outside and look at the flue vent.**
 4. **Test your CO detectors.**
 
-That's it. Twenty minutes of your time. It prevents probably 80% of the calls we get in October and November.
+That's it. Twenty minutes of your time. It prevents many of the avoidable calls we get in October and November.
 
 And if something feels off when you run it, call us. We'd rather come out on a warm day and catch a dying igniter before it leaves you in the cold than show up at midnight with a frozen house and a kid in a sleeping bag on the couch.
 
 We've done both. The warm-day version is a lot nicer for everyone.
+
+Official references worth keeping handy:
+
+- [CPSC: Carbon Monoxide Alarms](https://www.cpsc.gov/Safety-Education/Safety-Education-Centers/Carbon-Monoxide-Information-Center/CO-Alarms)
+- [Department of Energy: Heat Distribution Systems](https://www.energy.gov/energysaver/heat-distribution-systems)

--- a/content/blog/heat-pump-vs-furnace-utah.md
+++ b/content/blog/heat-pump-vs-furnace-utah.md
@@ -19,7 +19,7 @@ We get this question every week now, and the answer is more complicated than eit
 
 The utility rebate programs and the federal tax credits want you to believe heat pumps are the obvious future. The HVAC contractors who've been installing gas furnaces for 30 years want you to believe heat pumps are overhyped. Neither is giving you the whole picture.
 
-We install both. We have opinions. Here's what actually matters for a Utah homeowner trying to figure out which one belongs in their house.
+We install both. Air Express works on [heat pumps](/heat-pump.html), [furnaces](/furnace.html), [AC replacement](/ac-replacement.html), and [heating replacement](/heating-replacement.html), so the right recommendation depends on the house, utility setup, ducts, comfort goals, and current incentive proof.
 
 ## The quick version (for people who just want the answer)
 
@@ -45,9 +45,9 @@ We install both. We have opinions. Here's what actually matters for a Utah homeo
 
 For most of our Lehi customers, dual-fuel is the answer. But let's break down why.
 
-## How a heat pump actually works (the short version)
+## How does a heat pump actually work?
 
-An air-source heat pump is just an air conditioner that can run backwards. In summer, it pulls heat out of your house and dumps it outside — same as a regular AC. In winter, it does the opposite: it pulls heat OUT of the cold outdoor air and brings it INSIDE.
+An air-source heat pump is just an air conditioner that can run backwards. In summer, it pulls heat out of your house and dumps it outside — same as a regular AC. In winter, it does the opposite: it pulls heat OUT of the cold outdoor air and brings it INSIDE. The [Department of Energy](https://www.energy.gov/energysaver/air-source-heat-pumps) explains the same core principle: heat pumps transfer heat instead of creating it from combustion.
 
 Yes, even cold outdoor air has heat in it, from a physics standpoint. A modern cold-climate heat pump can still extract useful heat when it's 10°F outside. Older heat pumps from 10+ years ago couldn't do this well, which is where the "heat pumps don't work in cold climates" reputation comes from. Modern ones are different machines.
 
@@ -88,11 +88,11 @@ Before rebates, the heat pump is more expensive than either a furnace OR an AC b
 
 Suddenly heat pumps look much more reasonable. This is why the single most common good-case for a heat pump in Utah is: your AC is dying AND your furnace is getting old.
 
-## The rebates matter more than most people realize
+## Do heat pump rebates matter in Utah?
 
-The federal Inflation Reduction Act includes a 30% tax credit on qualified heat pump installations, capped at $2,000 for most systems. Utah's state and utility rebates stack on top: Dominion Energy offers rebates for dual-fuel systems, Rocky Mountain Power offers rebates for heat pumps, and the state periodically adds more on top of that.
+Rebates and tax credits can materially change the decision, but they must be checked at quote time. The federal home energy upgrade guidance lists heat-pump tax credits and rebate programs, and utility incentives can change by territory, equipment, income eligibility, and install date.
 
-Between all of them, a well-qualified Utah customer can knock $3,000-5,000 off the cost of a heat pump install. That's the difference between "same price as a furnace" and "actually cheaper than a furnace." We walk customers through the current available rebates on every heat pump quote because they change every year and they materially affect the decision.
+We walk customers through current available incentives on every heat-pump quote because they change and they materially affect the decision. Do not count an incentive until the equipment, installer, and eligibility are verified.
 
 ## Cold-climate performance: the thing people worry about
 
@@ -126,3 +126,9 @@ Heat pumps in Utah are legitimately good technology now. They're not a scam and 
 - How long you're staying in the house (matters for payback)
 
 If you want us to come look at what you have and run the actual numbers for your specific house, that's a free visit. We'll tell you what we'd install if it were our own house — same answer we give our own families. Sometimes it's a heat pump. Sometimes it's a furnace. Usually it's a dual-fuel system. Always it's the system that actually makes sense.
+
+Official references worth keeping handy:
+
+- [Department of Energy: Air-Source Heat Pumps](https://www.energy.gov/energysaver/air-source-heat-pumps)
+- [Department of Energy: Heat Pump Systems](https://www.energy.gov/energysaver/heat-pump-systems)
+- [Department of Energy: Home Upgrades](https://www.energy.gov/save/home-upgrades)

--- a/content/blog/hvac-glossary.md
+++ b/content/blog/hvac-glossary.md
@@ -22,6 +22,10 @@ Jump to a letter: [A](#a) · [B](#b) · [C](#c) · [D](#d) · [E](#e) · [F](#f)
 
 ---
 
+## What HVAC terms should Utah homeowners know first?
+
+If you only learn a few HVAC terms before a quote, start with AFUE, SEER2, heat pump, Manual J, MERV, static pressure, and tonnage. Those terms explain efficiency, sizing, filtration, airflow, and whether the proposed system fits the house. Use this glossary with Air Express service pages for [AC replacement](/ac-replacement.html), [heat pumps](/heat-pump.html), [furnace repair](/furnace-repair.html), and [ductwork](/ductwork.html).
+
 ## A
 
 ### AFUE
@@ -79,7 +83,7 @@ A movable plate inside ductwork that controls how much air flows through a parti
 A heat pump paired with a backup gas furnace, controlled by a smart thermostat that decides which one to use based on outdoor temperature. The heat pump handles mild weather efficiently. The furnace kicks in only when it's cold enough that the heat pump becomes inefficient. Best of both worlds — and our most-recommended setup for Utah Valley homes.
 
 ### Duct
-The metal or flexible tubing that carries conditioned air from your furnace/AC to the rooms in your house. "Supply ducts" deliver conditioned air. "Return ducts" pull room air back to the system. Most Utah homes have 20-40% of their conditioned air leaking out of duct seams before it ever reaches a room.
+The metal or flexible tubing that carries conditioned air from your furnace/AC to the rooms in your house. "Supply ducts" deliver conditioned air. "Return ducts" pull room air back to the system. The [Department of Energy](https://www.energy.gov/energysaver/minimizing-energy-losses-ducts) notes that poorly sealed or insulated ducts can contribute to higher energy bills, especially when ducts run through unconditioned spaces.
 
 ### Ductless Mini-Split
 A heat pump system with no ductwork. Each room (or zone) has its own indoor "head unit" mounted on a wall, all connected to a single outdoor compressor by small refrigerant lines. Common in Utah for cooling additions, finished basements, garages, or houses that were built without central AC.
@@ -154,7 +158,7 @@ The math an HVAC contractor runs to figure out exactly how many BTUs your house 
 ## M
 
 ### MERV
-**Minimum Efficiency Reporting Value.** The rating system for air filters. Higher MERV = catches smaller particles. MERV 8 is the cheap default, catches dust and pollen. MERV 11 catches mold spores and finer dust. MERV 13 catches viruses and most fine particulates. Most modern Utah furnaces handle MERV 11 or 13 just fine despite what older websites claim.
+**Minimum Efficiency Reporting Value.** The rating system for air filters. Higher MERV = catches smaller particles. MERV 8 is a common baseline for dust and pollen. MERV 11 catches finer dust and many smaller particles. MERV 13 can help with smoke and fine particulate filtration when the system can handle the airflow. Do not install a restrictive filter blindly; check equipment requirements and static pressure.
 
 ### Manual J / Manual D / Manual S
 The three calculations a real HVAC contractor uses. **Manual J** sizes the equipment by load. **Manual D** sizes the ductwork. **Manual S** selects the specific equipment. Together they're the only way to install a system that actually works as intended.
@@ -253,3 +257,9 @@ Want to read more before you call? Try:
 - **[HVAC Buying Guide for Utah](/blog/hvac-buying-guide.html)** — what to actually look for in a quote
 - **[What HVAC Costs in Utah](/blog/hvac-cost-guide.html)** — real 2026 price ranges
 - **[Heat Pump vs. Furnace](/blog/heat-pump-vs-furnace-utah.html)** — the honest comparison
+
+Official references worth keeping handy:
+
+- [Department of Energy: Air-Source Heat Pumps](https://www.energy.gov/energysaver/air-source-heat-pumps)
+- [Department of Energy: Minimizing Energy Losses in Ducts](https://www.energy.gov/energysaver/minimizing-energy-losses-ducts)
+- [CPSC: Carbon Monoxide Alarms](https://www.cpsc.gov/Safety-Education/Safety-Education-Centers/Carbon-Monoxide-Information-Center/CO-Alarms)

--- a/content/blog/summer-energy-efficiency.md
+++ b/content/blog/summer-energy-efficiency.md
@@ -21,57 +21,61 @@ Most of the time, nothing is wrong with their AC.
 
 The AC is doing exactly what it's supposed to do: pulling heat out of the house and dumping it outside. It's just that the house is leaking that heat back in faster than the AC can keep up. So the AC runs and runs and runs, the compressor cycles all day, and the power bill is brutal.
 
-Fixing that bill isn't about buying a bigger or newer AC. It's about figuring out where the heat is getting in.
+Fixing that bill usually is not about buying a bigger or newer AC first. It's about figuring out where the heat is getting in, where cooled air is being lost, and whether the system is moving the air it was designed to move.
 
-We've done hundreds of these diagnostic visits in Lehi, Saratoga Springs, and Eagle Mountain. Here's what we usually find.
+On comfort and efficiency visits in Lehi, Saratoga Springs, and Eagle Mountain, these are the patterns we usually investigate first.
 
-## The attic is almost always the problem.
+## Why does a Utah AC run all day in July?
+
+A Utah AC often runs all day because the home is gaining heat faster than the system can remove it. Attic heat, duct leakage, sunny windows, blocked airflow, dirty filters, and unrealistic thermostat recovery can all make a healthy AC look weak. Start with the building and airflow before assuming the equipment is too small.
+
+## Is the attic adding heat to the house?
 
 If your house was built in Utah anytime between 2000 and 2015, there's a very good chance your attic insulation is under-spec for what's actually needed to handle Utah summer heat.
 
-The building code at the time was R-38 for ceilings in this climate zone. That was considered good. It is not good. We now recommend R-49 to R-60 for Utah homes that want real summer efficiency. The difference between R-38 and R-60 in an attic on a 100-degree day is substantial — we're talking 10-15 degrees of temperature difference in the ceiling cavity, which directly translates to how hard your AC has to work.
+The right target depends on the home, but attic insulation and air sealing are a real cooling issue, not just a winter heating issue. The [Department of Energy's air-sealing guidance](https://www.energy.gov/energysaver/weatherize/air-sealing-your-home) recommends finding leaks, assessing ventilation needs, and sealing gaps before relying on uncontrolled air leakage.
 
-**What we actually check:** Go up into your attic (or send us up). Look at the insulation depth with a tape measure. Pink or yellow fiberglass batts at 12 inches deep = roughly R-38. You want closer to 18 inches of blown-in cellulose or fiberglass, which gets you to R-60.
+**What we actually check:** Go up into your attic (or send us up). Look at insulation depth, disturbed insulation, attic bypasses, recessed lights, bath-fan penetrations, and whether the attic hatch leaks. If the attic is part of the problem, [energy-efficiency](/energy-efficiency.html) improvements may help the AC work less hard.
 
-Adding insulation is one of the cheapest ways to lower your summer cooling bill. A typical Lehi home can get from R-38 to R-60 for $1,500-3,000 depending on attic size, and the payback on summer cooling alone is usually 4-6 years. Combined with winter heating savings, it's faster.
+Adding insulation or sealing attic leaks can help, but the scope and payback need to be verified house by house. Treat exact cost and savings claims as quote-specific, not universal.
 
-## Your ducts are probably leaking.
+## Are ducts leaking or under-delivering cooled air?
 
 This one shocks people. The ductwork that runs through your attic — the big silver metal or flex duct that carries conditioned air from your furnace/AC to the rooms — is often losing 20-30% of the cooled air through joints, seams, and connections BEFORE it ever reaches a register.
 
-In Utah, where most duct runs are in unconditioned attic space, this is even worse. You're paying to cool air that never actually makes it into your living room. It just leaks into the attic and slowly warms the rest of the house.
+In Utah, attic duct runs matter because they sit outside the conditioned space. The [Department of Energy duct guidance](https://www.energy.gov/energysaver/minimizing-energy-losses-ducts) says poorly sealed or insulated ducts can contribute to higher energy bills and recommends professional sealing and insulating when ducts are in unconditioned spaces.
 
-We test duct systems with a manometer — a device that measures pressure loss. It's not a guess. In an average Utah home from the mid-2000s, we typically find 15-25% duct leakage. In a well-sealed modern home, it's 5% or less.
+We test duct systems with static-pressure and airflow checks. It's not a guess. If the ducts are undersized, leaking, crushed, or poorly balanced, you can have a good AC and still get hot rooms.
 
-**What actually fixes it:** Mastic sealing (thick gray paint-like stuff applied at every joint) or Aeroseal (a pressurized aerosol sealant that gets applied from the inside). Mastic is cheaper and we can do it in a few hours. Aeroseal is more expensive but gets into places you can't reach by hand.
+**What actually fixes it:** sometimes mastic sealing, sometimes duct repair, sometimes return-air changes, sometimes balancing. Start with [ductwork](/ductwork.html) and airflow diagnostics before replacing equipment.
 
-Either way, the improvement in cooling efficiency is immediate and measurable. We've had customers call us the next week to say their upstairs bedrooms are actually cool for the first time in years.
+Either way, the improvement should be measured with better airflow, better room comfort, or shorter run-time pressure on the system.
 
-## South-facing windows are doing more than you think.
+## Are sunny windows driving afternoon heat gain?
 
 If your house has large south-facing or west-facing windows — and a lot of Utah homes do because of the mountain views — those windows are passive solar heaters all afternoon.
 
-A single 4x6-foot west-facing window with no coverage can contribute the equivalent of a 1,500-watt space heater worth of heat gain during a hot July afternoon. Multiply that by three or four windows in a great room and you understand why your AC can't keep up at 4pm.
+The [Department of Energy's cooling principles](https://www.energy.gov/energysaver/principles-heating-and-cooling) explain the problem simply: sunlight and radiant heat can add real load to a home. If the rooms that struggle are on the west or south side, windows and shade belong in the diagnosis.
 
 **Cheap fix:** close the blinds or curtains on the sunny side of the house during peak afternoon hours. Sounds obvious but nobody does it. Just doing this can take 3-5 degrees off the upstairs temperature during the worst part of the day.
 
-**Better fix:** low-E window film on the hot-side windows. It looks almost invisible from the outside, rejects 60-80% of the solar heat gain, and still lets visible light through. A professional install runs $5-8 per square foot and pays back within a couple summers for houses with big sunny exposures.
+**Better fix:** exterior shade, solar screens, or window film where appropriate. The right answer depends on window type, HOA rules, view priorities, and how much heat gain is actually coming through that glass.
 
 **Best fix (if you're replacing windows anyway):** low-E Argon-filled double-pane windows with a low SHGC rating for the sun-side, higher SHGC for the cold-side. But this is a big-ticket project and only makes sense if you were planning window work anyway.
 
-## The thermostat setting game.
+## What thermostat strategy actually helps in July?
 
 There's a lot of conventional wisdom about thermostat settings that actually costs you money.
 
-**"Set it higher when you leave the house."** Sort of true, but only if you're gone for 4+ hours. Setting the thermostat up 6-8 degrees when you leave for work and back down when you get home saves about 5-10% on cooling. Setting it up 3 degrees when you run to the store doesn't.
+**"Set it higher when you leave the house."** Sort of true, but the size and timing of the setback matter. The [Department of Energy thermostat guidance](https://www.energy.gov/energysaver/articles/thermostats) supports warmer cooling settings when away and avoiding unnecessary overcooling.
 
 **"Don't turn it off, it costs more to cool back down."** Completely false. This is a myth. It always costs less to let the house warm up while you're gone than to keep cooling it. The energy you save during the coast-up period is more than the energy spent bringing it back down later.
 
 **"Close vents in rooms you don't use."** Don't. This was true for old gravity systems. It's false for any modern forced-air system. Closing vents raises static pressure in the ducts, stresses the blower, and usually causes more duct leakage, not less.
 
-**What actually works:** a smart thermostat with a learning schedule (Nest, Ecobee, Honeywell T10, etc.) set to 76-78 during occupied hours, 82-84 during away hours. That's the sweet spot for Utah summer. It's a bit warmer than people feel comfortable with initially, but if you run a ceiling fan in the room you're in, 78 feels like 74.
+**What actually works:** use the highest comfortable occupied setting, a warmer away setting when the house will be empty long enough for it to matter, and a schedule that avoids forcing the system to recover a large gap during the hottest part of the afternoon. Air Express can review [thermostats](/thermostats.html), [AC inspections](/ac-inspection.html), and [AC maintenance](/ac-maintenance.html) if the schedule cannot hold.
 
-## The ceiling fan trick.
+## Do ceiling fans lower AC load?
 
 A ceiling fan doesn't cool the air. It cools YOU, by moving air across your skin and increasing evaporative heat loss. This is important because it means:
 
@@ -79,7 +83,7 @@ A ceiling fan doesn't cool the air. It cools YOU, by moving air across your skin
 2. A ceiling fan running in a room with people in it effectively lowers the "felt" temperature by 4-6 degrees, meaning you can set the thermostat higher without feeling hotter.
 3. Turn it off when you leave the room. Really.
 
-On a summer evening in Lehi, running ceiling fans with the thermostat at 78 uses dramatically less energy than running no fans with the thermostat at 74. The human comfort is identical.
+The [Department of Energy fan guidance](https://www.energy.gov/energysaver/fans-cooling) says ceiling fans can let people raise the thermostat setting by about 4 degrees without reducing comfort. The key is running fans in occupied rooms, not empty ones.
 
 ## The stuff that matters most, in order.
 
@@ -98,3 +102,9 @@ Notice what's NOT on this list: replacing your AC. If your AC is under 10 years 
 If you want to know what's actually causing your July bills, we do a summer efficiency walkthrough. We look at the attic, the ducts, the windows, the thermostat schedule, the AC itself, and give you an honest ranked list of what would actually move the needle.
 
 No upsell. No pressure. Sometimes the answer is "nothing is wrong, your house is just big and Utah is hot." That's fine too — at least then you know.
+
+Official references worth keeping handy:
+
+- [Department of Energy: Air Sealing Your Home](https://www.energy.gov/energysaver/weatherize/air-sealing-your-home)
+- [Department of Energy: Minimizing Energy Losses in Ducts](https://www.energy.gov/energysaver/minimizing-energy-losses-ducts)
+- [Department of Energy: Fans for Cooling](https://www.energy.gov/energysaver/fans-cooling)

--- a/content/blog/thermostat-settings-utah-heat-wave.md
+++ b/content/blog/thermostat-settings-utah-heat-wave.md
@@ -20,6 +20,10 @@ Someone sets it lower because the living room feels warm. Someone else raises it
 
 The thermostat matters, but it is not magic. It can help a healthy system run smarter. It cannot overcome a clogged filter, weak blower, dirty outdoor coil, leaking ductwork, or a system that is undersized for the home.
 
+## What thermostat setting helps most during a Utah heat wave?
+
+The best heat-wave setting is the highest comfortable cooling setpoint your home can hold steadily. The [Department of Energy thermostat guidance](https://www.energy.gov/energysaver/articles/thermostats) recommends using warmer away settings for cooling season and warns that setting the AC colder than normal will not cool the home faster. In Utah, pair the schedule with filter, airflow, and afternoon heat-gain checks.
+
 ## Use smaller schedule changes on extreme days
 
 Away setbacks are useful, but on the hottest days a large setback can push the recovery period into the worst part of the afternoon.
@@ -67,4 +71,5 @@ The best heat-wave setting is the one your home can realistically maintain. Star
 Official references worth keeping handy:
 
 - [ENERGY STAR: Smart Thermostats](https://www.energystar.gov/products/smart_thermostats)
+- [Department of Energy: Programmable Thermostats](https://www.energy.gov/energysaver/articles/thermostats)
 - [Department of Energy: Fans for Cooling](https://www.energy.gov/energysaver/fans-cooling)

--- a/content/blog/wildfire-smoke-hvac-filter-utah.md
+++ b/content/blog/wildfire-smoke-hvac-filter-utah.md
@@ -20,6 +20,10 @@ Your HVAC system can help, but only if the filter and fan strategy match the hou
 
 For current Utah smoke conditions, start with the [Utah Division of Air Quality wildfire resources](https://deq.utah.gov/air-quality/wildfires), [UtahAir](https://air.utah.gov/), or the [AirNow Fire and Smoke Map](https://fire.airnow.gov/). Those sources tell you when the outdoor air is bad enough that indoor-air choices matter more than usual.
 
+## What should Utah homeowners do with HVAC during wildfire smoke?
+
+During smoke or poor PM2.5 periods, keep outdoor air out as much as safely practical, filter the air your system recirculates, and use room-level filtration where people sleep. The EPA recommends a MERV 13 filter or the highest rating your HVAC system can accommodate during smoke events, but airflow and static pressure still matter.
+
 ## Use the best filter your system can handle
 
 For smoke and fine particulate days, a better pleated filter can help reduce what recirculates through the home. Many modern systems can handle MERV 11, and some can handle MERV 13, especially with a 4-inch media cabinet.
@@ -57,5 +61,6 @@ For Utah homes, the practical stack is simple: the right HVAC filter, controlled
 Official references worth keeping handy:
 
 - [Utah DEQ: Protect Yourself From Wildfire Smoke](https://deq.utah.gov/air-quality/protect-yourself-from-wildfire-smoke)
-- [EPA: Wildfires and Indoor Air Quality](https://www.epa.gov/indoor-air-quality-iaq/wildfires-and-indoor-air-quality-iaq)
-- [AirNow: Be Smoke Ready](https://www.airnow.gov/wildfires/be-smoke-ready)
+- [EPA: Wildfires and Indoor Air Quality](https://www.epa.gov/emergencies-iaq/wildfires-and-indoor-air-quality-iaq)
+- [EPA: Preparing for Smoke and Heat](https://www.epa.gov/wildfire-smoke-course/preparing-smoke-and-heat)
+- [AirNow: Indoor Air Filtration](https://www.airnow.gov/publications/wildfire-guide-factsheets/wildfire-smoke-indoor-air-filtration-factsheet/)


### PR DESCRIPTION
## TL;DR

- Adds question-answer blocks, internal service links, and official-source citations to the remaining Air Express draft/future blog posts.
- Removes several unsupported or overly broad savings/rebate/lifespan-style claims in favor of source-backed, quote-specific language.
- Refs #33 and supports #39; no draft is published by this PR.

## Validation

- `git diff --check`
- Mirrored private-report build/evidence run: `npm run build:blog`, `npm run audit:seo-geo-deep-dive`, `npm run verify:onboarding-evidence`, `npm run refresh:air-express-evidence`

## Boundaries

- No provider mutation, DNS change, deploy command, public send, social post, GBP post, or ServiceTitan action was performed from this PR.
- Draft posts remain draft-gated until Max/New Reward approval and publication evidence exist.